### PR TITLE
Ensure manifest metadata and installation docs for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Kayak ➜ *I Chrome extension
+
+This repository contains an unpacked Chromium extension that adds a “*I” copy pill to expanded Kayak itineraries and a popup to configure booking class and segment status defaults.
+
+## Installation
+
+1. Download the repository as a ZIP file or clone it locally.
+2. If you downloaded the ZIP on Windows, right-click the file, choose **Properties** and click **Unblock** before extracting. This prevents Windows from marking the files as untrusted, which can stop Chromium-based browsers from reading the manifest.
+3. Extract the archive so that `manifest.json` and the rest of the source files sit directly inside the folder you load.
+4. Open `chrome://extensions` (or the equivalent in Edge), enable **Developer mode**, and choose **Load unpacked**.
+5. Select the folder that contains `manifest.json`.
+
+Once loaded, open the popup to adjust booking class or segment status defaults.
+
+## Development
+
+The project is a plain JavaScript extension. There is no build step. Run `npx web-ext lint` to perform add-on validation.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 3,
-  "name": "Kayak \u279c *I (GDS)",
+  "name": "Kayak ➜ *I (GDS)",
   "version": "2.0.0",
   "description": "On expanded Kayak cards, shows a *I pill that copies the itinerary in *I GDS format. Popup has booking class + segment status settings.",
   "icons": {
@@ -32,8 +32,13 @@
       "all_frames": true
     }
   ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "kayak-copy@example.com"
+    }
+  },
   "action": {
-    "default_title": "Kayak \u279c *I",
+    "default_title": "Kayak ➜ *I",
     "default_popup": "popup.html"
   }
 }


### PR DESCRIPTION
## Summary
- update the manifest metadata to use a literal arrow glyph and add a Gecko extension id for MV3 compatibility
- add documentation that walks through extracting the zip and loading the extension, including the Windows "Unblock" step so the manifest is readable

## Testing
- `npx web-ext lint`


------
https://chatgpt.com/codex/tasks/task_e_68ccc6a340348326b9d15bfcf2906bc7