### PR TITLE
Fix itinerary copy header parsing and button label

### DIFF
--- a/content.js
+++ b/content.js
@@ -138,7 +138,7 @@
     btn.type = 'button';
     btn.title = 'Copy *I itinerary';
     btn.setAttribute('aria-label', 'Copy star-I itinerary');
-    btn.innerHTML = '<span aria-hidden="true" class="pill">*I</span><span class="label">Copy</span>';
+    btn.innerHTML = '<span aria-hidden="true" class="pill">*I</span>';
 
     card.classList.add(ROOT_CLASS);
     card.appendChild(btn);

--- a/converter.js
+++ b/converter.js
@@ -23,7 +23,7 @@
 
   function parseHeaderDate(line){
     // "Depart • Sat, Oct 4" -> {dow:'J', day:'04', mon:'OCT'}
-    const m = line.match(/(Depart|Return)\s*•\s*(Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s*([A-Za-z]{3,})\s*(\d{1,2})/i);
+    const m = line.match(/(Depart|Return)\s*(?:[•·-]\s*)?(Sun|Mon|Tue|Wed|Thu|Fri|Sat),\s*([A-Za-z]{3,})\s*(\d{1,2})/i);
     if(!m) return null;
     const dow = DOW_CODE[m[2].toUpperCase().slice(0,3)];
     const mon = m[3].toUpperCase().slice(0,3);
@@ -158,7 +158,7 @@
     // return [{headerDate, lines: [...]}, ...] for Depart and Return
     const indices = [];
     for(let i=0;i<lines.length;i++){
-      if(/^Depart\s*•/i.test(lines[i]) || /^Return\s*•/i.test(lines[i])) indices.push(i);
+      if(/^Depart(?:\s*[•·-])?\s+/i.test(lines[i]) || /^Return(?:\s*[•·-])?\s+/i.test(lines[i])) indices.push(i);
     }
     if(indices.length===0) return [];
     const sections = [];


### PR DESCRIPTION
## Summary
- update the injected button so it only renders a *I pill
- relax itinerary header parsing so converters handle dots and hyphen separators

## Testing
- node - <<'NODE' ... (sample itinerary conversion)


------
https://chatgpt.com/codex/tasks/task_e_68ccd2a8af8c8326ba950fc60374e21d