### PR TITLE
Handle airline name and flight number split across lines

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -118,6 +118,19 @@
       };
     }
 
+    // Support airline name on one line and flight number on the next
+    const nameOnly = raw.trim().toUpperCase();
+    if(AIRLINE_CODES[nameOnly] && (idx + 1) < lines.length){
+      const next = (lines[idx + 1] || '').trim();
+      if(/^\d{1,4}$/.test(next)){
+        return {
+          airlineCode: AIRLINE_CODES[nameOnly],
+          number: next,
+          index: idx + 1
+        };
+      }
+    }
+
     const designatorRe = /\b([A-Z0-9]{2,3})(?:\s|-)?(\d{1,4})\b/g;
     let match;
     while((match = designatorRe.exec(raw))){


### PR DESCRIPTION
## Summary
- treat airline name lines followed by numeric lines as a single flight when building *I output

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ccd981a4d0832694c8b25fee7e2207