### PR TITLE
Fix copy button placement and itinerary parsing

### DIFF
--- a/content.js
+++ b/content.js
@@ -148,19 +148,8 @@
     btn.setAttribute('aria-label', 'Copy star-I itinerary');
     btn.innerHTML = '<span aria-hidden="true" class="pill">*I</span>';
 
-    const anchor = selectBtn.parentElement || card;
-    const anchorStyle = getComputedStyle(anchor);
-    const needsAnchorPosition = anchorStyle.position === 'static';
-    if (needsAnchorPosition) {
-      anchor.style.position = 'relative';
-    }
-    btn.dataset.anchorReset = needsAnchorPosition ? '1' : '';
-    btn.style.position = 'absolute';
-    btn.style.top = '50%';
-    btn.style.marginTop = '-22px';
-    btn.style.right = '0.5rem';
-
-    anchor.appendChild(btn);
+    card.classList.add(ROOT_CLASS);
+    card.appendChild(btn);
 
     btn.addEventListener('click', async (ev) => {
       ev.preventDefault();

--- a/converter.js
+++ b/converter.js
@@ -298,7 +298,31 @@
       expanded.push(line);
     }
 
-    return expanded;
+    const normalized = [];
+    const headerOnly = /^(Depart(?:ure)?|Return|Outbound|Inbound)$/i;
+
+    for (let i = 0; i < expanded.length; i++) {
+      const line = expanded[i];
+      if (headerOnly.test(line)) {
+        let combined = line;
+        let consumed = 0;
+        for (let look = 1; look <= 3 && (i + look) < expanded.length; look++) {
+          combined += ' ' + expanded[i + look];
+          if (parseHeaderDate(combined)) {
+            normalized.push(combined);
+            consumed = look;
+            break;
+          }
+        }
+        if (consumed) {
+          i += consumed;
+          continue;
+        }
+      }
+      normalized.push(line);
+    }
+
+    return normalized;
   }
 
   // Public API


### PR DESCRIPTION
## Summary
- anchor the floating *I button to the fare card and rely on existing CSS so it stays in the top-right corner
- normalize extracted header lines in the converter so split "Depart"/"Return" headings still parse into sections

## Testing
- node - <<'NODE'
global.window = global;
// Provide minimal airline codes for the test
global.AIRLINE_CODES = {'UNITED AIRLINES':'UA'};
require('./converter.js');
const input = `Depart
• Sat, Oct 4
United Airlines 949
Boeing 777
8:00 pm San Francisco (SFO)
1 stop 17h 48m
1h 20m Honolulu (HNL)
3:25 pm +1
London (LHR)
Limited seats remaining at this price
Return
Thu, Oct 23
United Airlines 958
Boeing 777
8:10 pm London (LHR)
10h 15m
10:25 am San Francisco (SFO)`;
console.log(window.convertTextToI(input));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ccdf3c63e483269756d78f6999c8b1