### PR TITLE
Copy option details from Kayak cards

### DIFF
--- a/content.js
+++ b/content.js
@@ -144,8 +144,8 @@
     const btn = document.createElement('button');
     btn.className = BTN_CLASS;
     btn.type = 'button';
-    btn.title = 'Copy *I itinerary';
-    btn.setAttribute('aria-label', 'Copy star-I itinerary');
+    btn.title = 'Copy option details';
+    btn.setAttribute('aria-label', 'Copy itinerary option details');
     btn.innerHTML = '<span aria-hidden="true" class="pill">*I</span>';
 
     card.classList.add(ROOT_CLASS);
@@ -156,14 +156,10 @@
       ev.stopPropagation();
       try{
         const raw = extractVisibleText(card);
-        const txt = window.convertTextToI(raw, {
-          bookingClass:  SETTINGS.bookingClass,
-          segmentStatus: SETTINGS.segmentStatus
-        });
-        await navigator.clipboard.writeText(txt);
-        toast('*I copied');
+        await navigator.clipboard.writeText(raw);
+        toast('Option details copied');
       }catch(err){
-        console.error('Copy *I failed:', err);
+        console.error('Copy option failed:', err);
         toast(err?.message || 'Copy failed');
       }
     });


### PR DESCRIPTION
## Summary
- update the Kayak copy button to capture the card's visible itinerary details instead of producing a *I string
- adjust the button label, aria text, and toast messaging to reflect the new behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cce23758d88326b4d4b06c49e0f4db