### PR TITLE
Fix itinerary output newline

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -342,7 +342,7 @@
     // Renumber across whole journey
     let n=1;
     const numbered = outLines.map(l => l.replace(/^\s*\d+/, String(n++).padStart(2,' ')));
-    return numbered.join('\\n');
+    return numbered.join('\n');
   };
 
   // Dead-stub helpers for later


### PR DESCRIPTION
## Summary
- ensure the itinerary formatter joins segments with a real newline character instead of a literal `\n`

## Testing
- npx web-ext lint

------
https://chatgpt.com/codex/tasks/task_e_68cea5f99af08326bac6d4ab7e7873e7