### PR TITLE
Fix departure dates after overnight connections

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -178,6 +178,7 @@
     // Build segments by scanning patterns: Airline [optional], "Airline NNNN", times and airports
     const segs = [];
     let i=0;
+    let currentDate = headerDate ? { ...headerDate } : null;
     while(i<lines.length){
       // Seek a flight number line
       let flightInfo=null, j=i;
@@ -221,17 +222,31 @@
       if(depTime && depAirport && arrTime && arrAirport){
         const airlineCode = flightInfo.airlineCode;
         const flightNumber = flightInfo.number;
+        const depDateString = currentDate ? `${currentDate.day}${currentDate.mon}` : '';
+        const depDow = currentDate ? currentDate.dow : '';
+        const arrDateString = arrivesDate
+          ? `${arrivesDate.day}${arrivesDate.mon}${arrivesDate.dow ? ` ${arrivesDate.dow}` : ''}`
+          : "";
         segs.push({
           airlineCode,
           number: flightNumber,
-          depDate: `${headerDate.day}${headerDate.mon}`,
-          depDOW: headerDate.dow,
+          depDate: depDateString,
+          depDOW: depDow,
           depAirport,
           arrAirport,
           depGDS: depTime.gds,
           arrGDS: arrTime.gds,
-          arrDate: arrivesDate ? `${arrivesDate.day}${arrivesDate.mon} ${arrivesDate.dow}` : ""
+          arrDate: arrDateString
         });
+        if(arrivesDate){
+          const prevDow = currentDate ? currentDate.dow : '';
+          const nextDow = prevDow || arrivesDate.dow || '';
+          currentDate = {
+            day: arrivesDate.day,
+            mon: arrivesDate.mon,
+            dow: nextDow
+          };
+        }
         i = k; // continue scan after what we consumed
       }else{
         i = flightInfo.index + 1;


### PR DESCRIPTION
## Summary
- carry forward the most recent travel date when converting itinerary sections so subsequent legs inherit arrival dates
- keep the original day-of-week code unless none was provided while still storing formatted arrival dates

## Testing
- node - <<'NODE' ... (sample itinerary conversion)


------
https://chatgpt.com/codex/tasks/task_e_68ceb2a038b883269d7d21075ef23437