### PR TITLE
Add configurable copy buttons with animation

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,43 +1,92 @@
-.kayak-copy-btn{
+.kayak-copy-btn-group{
   position:absolute;
-  top:10px; right:10px;
-  display:inline-flex; align-items:center; justify-content:center;
-  width:44px; height:44px;
+  top:10px;
+  right:10px;
+  display:flex;
+  gap:8px;
+  z-index:2147483000;
+}
+
+.kayak-copy-btn{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:44px;
+  height:44px;
   padding:0;
   border-radius:50%;
-  border:2px solid rgba(255,255,255,.8);
+  border:2px solid rgba(255,255,255,.82);
   background:linear-gradient(180deg, rgba(255,255,255,.95) 0%, rgba(238,241,245,.95) 100%);
   box-shadow:0 4px 14px rgba(9,19,33,.25);
-  cursor:pointer; z-index:2147483000;
+  cursor:pointer;
   backdrop-filter:saturate(1.1) blur(3px);
-  transition:transform .18s ease, box-shadow .18s ease;
+  transition:transform .18s ease, box-shadow .18s ease, background .22s ease, border-color .22s ease;
   font:700 14px/1 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   color:#101a2a;
+  overflow:hidden;
 }
 .kayak-copy-btn:hover{ transform:translateY(-2px); box-shadow:0 6px 18px rgba(9,19,33,.32); }
 .kayak-copy-btn:active{ transform:translateY(0); box-shadow:0 3px 10px rgba(9,19,33,.25); }
 
-.kayak-copy-btn .pill{
-  font-weight:700;
-  display:inline-flex;
+.kayak-copy-btn .pill-text,
+.kayak-copy-btn .pill-check{
+  position:absolute;
+  inset:0;
+  display:flex;
   align-items:center;
   justify-content:center;
-  width:100%; height:100%;
+  width:100%;
+  height:100%;
   letter-spacing:.04em;
+  transition:opacity .18s ease, transform .18s ease;
 }
-.kayak-copy-btn .label{
-  font-weight:600;
-  text-transform:uppercase;
-  font-size:11px;
-  letter-spacing:.02em;
+.kayak-copy-btn .pill-text{ color:inherit; }
+.kayak-copy-btn .pill-check{
+  font-size:20px;
+  opacity:0;
+  transform:scale(.6);
+  color:#fff;
 }
+
+.kayak-copy-btn.is-copied{
+  background:linear-gradient(180deg, #2dd36f 0%, #1ea85a 100%);
+  border-color:rgba(255,255,255,.92);
+  color:#fff;
+  box-shadow:0 6px 18px rgba(12,94,40,.38);
+}
+.kayak-copy-btn.is-copied .pill-text{ opacity:0; transform:scale(.7); }
+.kayak-copy-btn.is-copied .pill-check{ opacity:1; transform:scale(1); }
+.kayak-copy-btn.is-copied::after{
+  content:'';
+  position:absolute;
+  inset:-4px;
+  border-radius:50%;
+  border:2px solid rgba(45,211,111,.45);
+  pointer-events:none;
+  animation:kayak-copy-ping .45s ease-out forwards;
+}
+
+@keyframes kayak-copy-ping{
+  from{ transform:scale(.8); opacity:.7; }
+  to{ transform:scale(1.35); opacity:0; }
+}
+
 .kayak-copy-toast{
-  position:fixed; left:50%; bottom:24px; transform:translateX(-50%);
-  padding:10px 14px; border-radius:10px;
-  background:rgba(20,22,28,.96); color:#fff;
+  position:fixed;
+  left:50%;
+  bottom:24px;
+  transform:translateX(-50%);
+  padding:10px 14px;
+  border-radius:10px;
+  background:rgba(20,22,28,.96);
+  color:#fff;
   font:500 13px/1.2 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
-  box-shadow:0 6px 18px rgba(0,0,0,.3); z-index:2147483647;
-  opacity:0; transition:opacity .18s ease, transform .18s ease;
+  box-shadow:0 6px 18px rgba(0,0,0,.3);
+  z-index:2147483647;
+  opacity:0;
+  transition:opacity .18s ease, transform .18s ease;
 }
 .kayak-copy-toast.show{ opacity:1; transform:translateX(-50%) translateY(-4px); }
+
 .kayak-copy-root{ position:relative !important; }

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,9 @@
     .row{ display:flex; gap:12px; align-items:center; }
     button{ margin-top:12px; padding:8px 12px; border-radius:8px; border:1px solid #c7c7c7; background:#fff; cursor:pointer; font-weight:600; }
     .ok{ color:#0a7; margin-left:8px; display:none; font-weight:600; }
+    .toggle{ display:flex; align-items:center; gap:8px; margin:18px 0 4px; font-weight:600; }
+    .toggle input{ width:auto; margin:0; }
+    .toggle-help{ display:block; margin-left:26px; margin-top:-2px; font-size:12px; color:#666; }
   </style>
 </head>
 <body>
@@ -26,6 +29,8 @@
       <small>3 chars</small>
     </div>
   </div>
+  <label class="toggle"><input id="enableDirections" type="checkbox" /> Show *IB / *OB buttons</label>
+  <small class="toggle-help">Adds inbound and outbound copy buttons next to *I.</small>
   <button id="saveBtn">Save</button><span id="ok" class="ok">Saved</span>
 
   <script src="popup.js"></script>

--- a/popup.js
+++ b/popup.js
@@ -1,18 +1,21 @@
 (() => {
   const booking = document.getElementById('bookingClass');
   const status  = document.getElementById('segmentStatus');
+  const enableDirections = document.getElementById('enableDirections');
   const okEl    = document.getElementById('ok');
   const saveBtn = document.getElementById('saveBtn');
 
-  chrome.storage.sync.get(['bookingClass','segmentStatus'], (res)=>{
+  chrome.storage.sync.get(['bookingClass','segmentStatus','enableDirectionButtons'], (res)=>{
     booking.value = (res.bookingClass || 'J').toUpperCase().slice(0,1);
     status.value  = (res.segmentStatus || 'SS1').toUpperCase().slice(0,3);
+    enableDirections.checked = !!res.enableDirectionButtons;
   });
 
   saveBtn.addEventListener('click', ()=>{
     const bc = (booking.value || 'J').toUpperCase().slice(0,1);
     const ss = (status.value || 'SS1').toUpperCase().slice(0,3);
-    chrome.storage.sync.set({ bookingClass: bc, segmentStatus: ss }, ()=>{
+    const enableDir = !!enableDirections.checked;
+    chrome.storage.sync.set({ bookingClass: bc, segmentStatus: ss, enableDirectionButtons: enableDir }, ()=>{
       okEl.textContent = 'saved';
       okEl.style.display = 'inline-block';
       // close after a short confirmation


### PR DESCRIPTION
## Summary
- add grouped copy buttons that ignore non-flight containers and can optionally expose *IB/*OB actions
- animate the copy buttons to morph into a green checkmark on successful clipboard writes
- extend the converter and popup settings to support outbound and inbound only copy commands

## Testing
- not run (extension)


------
https://chatgpt.com/codex/tasks/task_e_68ceb560cb488326a62a4f9ee994c751