### PR TITLE
Handle departs overrides and availability commands

### DIFF
--- a/content.js
+++ b/content.js
@@ -132,16 +132,18 @@
         if(!raw || !raw.trim()){
           throw new Error('No itinerary details found');
         }
-        const opts = {
+        const baseOpts = {
           bookingClass: SETTINGS.bookingClass,
           segmentStatus: SETTINGS.segmentStatus
         };
-        if(config.direction && config.direction !== 'all'){
-          opts.direction = config.direction;
-        }
+        const direction = config.direction || 'all';
         let converted;
         try {
-          converted = window.convertTextToI(raw, opts);
+          if(direction === 'all'){
+            converted = window.convertTextToI(raw, baseOpts);
+          }else{
+            converted = window.convertTextToAvailability(raw, { direction });
+          }
         } catch (parseErr) {
           console.error('Conversion failed:', parseErr);
           throw new Error(parseErr?.message || 'Conversion failed');


### PR DESCRIPTION
## Summary
- parse "Departs" override lines while collecting segments so continuing legs get the correct departure date and day of week
- add helpers to reuse parsed segments for both *I formatting and building Sabre availability commands with deduped airlines and transit points
- switch the outbound/inbound buttons to copy the new availability command instead of partial *I text

## Testing
- node - <<'NODE' (Aer Lingus outbound sample) 【e0fcb7†L1-L32】
- node - <<'NODE' (round-trip sample) 【f648c4†L1-L33】
- node - <<'NODE' (Austrian/Lufthansa sample) 【b77c02†L1-L32】

------
https://chatgpt.com/codex/tasks/task_e_68cee4baf220832683b40ccf2a556c9a