### PR TITLE
Keep copy pills visible while cards stay expanded

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,10 +1,21 @@
+#kayak-copy-overlay-root{
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  z-index:2147483000;
+}
+
+#kayak-copy-overlay-root .kayak-copy-btn-group{
+  pointer-events:auto;
+}
+
 .kayak-copy-btn-group{
-  position:absolute;
-  top:10px;
-  right:10px;
+  position:fixed;
+  top:0;
+  left:0;
   display:flex;
   gap:8px;
-  z-index:2147483000;
+  z-index:2147483001;
 }
 
 .kayak-copy-btn{
@@ -89,4 +100,3 @@
 }
 .kayak-copy-toast.show{ opacity:1; transform:translateX(-50%) translateY(-4px); }
 
-.kayak-copy-root{ position:relative !important; }


### PR DESCRIPTION
## Summary
- render copy button groups inside a fixed overlay root and track card-to-group mappings so SPA re-renders or hover changes do not remove the pills
- schedule position updates via ResizeObserver, scroll/resize listeners, and mutation hooks to keep pills aligned with expanded cards while hiding when cards disappear
- update injected styles to support the global overlay container instead of card-relative positioning

## Testing
- Not run (extension has no automated test suite)


------
https://chatgpt.com/codex/tasks/task_e_68cf016229f88326b752a9c5f9478043