### PR TITLE
Add ITA Matrix support and parse booking classes

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,6 +2,9 @@
 (() => {
   'use strict';
 
+  const HOSTNAME = (location && location.hostname) || '';
+  const IS_ITA = /(?:^|\.)matrix\.itasoftware\.com$/i.test(HOSTNAME);
+
   const BTN_CLASS    = 'kayak-copy-btn';
   const BTN_GROUP_CLASS = 'kayak-copy-btn-group';
   const BTN_GROUP_SEL   = '.' + BTN_GROUP_CLASS;
@@ -194,6 +197,15 @@
     const r = el.getBoundingClientRect();
     if (r.height < 220 || r.width < 280) return false;
     const txt = (el.innerText || '');
+
+    if(IS_ITA){
+      const routeLike = /\([A-Z]{3}\)[^\n]+?\bto\b[^\n]+?\([A-Z]{3}\)/i.test(txt);
+      if(!routeLike) return false;
+      const timeMatches = txt.match(/(?:[01]?\d|2[0-3]):[0-5]\d(?:\s?(?:am|pm))?/ig) || [];
+      if(timeMatches.length < 2) return false;
+      return true;
+    }
+
     const hasDepartLike = /\b(Depart|Departure|Outbound)\b/i.test(txt);
     const hasReturnLike = /\b(Return|Inbound|Arrival)\b/i.test(txt);
     if (!hasDepartLike && !hasReturnLike) return false;
@@ -282,15 +294,17 @@
     }
 
     const selectBtn = findSelectButton(card);
-    if (!selectBtn){
+    if (!selectBtn && !IS_ITA){
       removeCardButton(card);
       return;
     }
 
-    const selectRect = selectBtn.getBoundingClientRect();
-    if (selectRect.width < 80 || selectRect.height < 28){
-      removeCardButton(card);
-      return;
+    if(selectBtn){
+      const selectRect = selectBtn.getBoundingClientRect();
+      if (selectRect.width < 80 || selectRect.height < 28){
+        removeCardButton(card);
+        return;
+      }
     }
 
     if(!cardHasFlightClues(card)){
@@ -350,6 +364,7 @@
       /^\$\d/, /Select/, /deal(s)?\s*from/i, /per\s*son/i,
       /Business Basic|Economy|Premium|Upper Class/i, /^Bags?$/i, /^Seat(s)?$/i, /^CO2/i
     ];
+    const bookingClassLike = /\(([A-Z0-9]{1,2})\)/;
 
     const dowPartLike = /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)(?:day)?[,]?$/i;
     const monthPartLike = /^(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)(?:\.?|,)?$/i;
@@ -359,7 +374,12 @@
     for(let i = 0; i < tokens.length; i++){
       const t = tokens[i];
       const next = tokens[i + 1] || '';
-      if (blacklist.some(rx => rx.test(t))) continue;
+      if (blacklist.some(rx => rx.test(t))){
+        if(bookingClassLike.test(t)){
+          keep.push(t);
+        }
+        continue;
+      }
 
       if (departHdr.test(t) || returnHdr.test(t) ||
           durationLike.test(t) || airlineLike.test(t) || aircraftLike.test(t) ||
@@ -444,11 +464,14 @@
 
   // Initial pass
   (function initialScan(){
+    const matchers = IS_ITA
+      ? [/\([A-Z]{3}\)\s+to\s+/i, /\bEconomy\b/i]
+      : [/\bDepart\b/i];
     const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT, {
       acceptNode(n){
         const v = (n.nodeValue || '').trim();
         if(!v) return NodeFilter.FILTER_SKIP;
-        if(/(^|\s)Depart\b/i.test(v)) return NodeFilter.FILTER_ACCEPT;
+        if(matchers.some(rx => rx.test(v))) return NodeFilter.FILTER_ACCEPT;
         return NodeFilter.FILTER_SKIP;
       }
     });


### PR DESCRIPTION
## Summary
- detect ITA Matrix result cards so the copy buttons appear without requiring a Select control
- preserve fare-class tokens while scraping card text so booking classes survive into conversion
- enhance the converter to read ITA-style route headers, capture segment booking classes, and split outbound/inbound segments even when "Depart" headers are missing

## Testing
- npx web-ext lint

------
https://chatgpt.com/codex/tasks/task_e_68cf03dc504c8326822ad91ffa934c64