### PR TITLE
Fix fallback time handling when parsing segments

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -340,8 +340,12 @@
         }
         if(backTimes.length){
           backTimes.reverse();
-          depTime = backTimes[0] || depTime;
-          if(backTimes.length > 1) arrTime = backTimes[1];
+          if((!depTime || depTime.mins == null) && backTimes[0] && backTimes[0].mins != null){
+            depTime = backTimes[0];
+          }
+          if((!arrTime || arrTime.mins == null) && backTimes.length > 1 && backTimes[1] && backTimes[1].mins != null){
+            arrTime = backTimes[1];
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- avoid overwriting parsed departure and arrival times with fallback values when parsing segments

## Testing
- npx web-ext lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0fb047d88326ab1bfd3c6d7e6320