### PR TITLE
Fix airline extraction to ignore equipment lines

### DIFF
--- a/content.js
+++ b/content.js
@@ -967,6 +967,7 @@
     const normalized = (line || '').replace(/\s+/g, ' ').trim().toUpperCase();
     if(!normalized) return false;
     if(/^[0-9]/.test(normalized)) return false;
+    if(/\b(AIRBUS|BOEING|EMBRAER|BOMBARDIER|CANADAIR|DE HAVILLAND|MCDONNELL|DOUGLAS|LOCKHEED|SUKHOI|SUPERJET|FOKKER|TUP|ANTONOV|IL-?\d*|SAAB|ATR|TURBOPROP|JETLINER|AIRCRAFT|E-?JET|CRJ|MAX|NEO)\b/.test(normalized)) return false;
     if(typeof AIRLINE_CODES !== 'undefined' && AIRLINE_CODES[normalized]) return true;
     const airlineKeywords = [
       'AIR ', 'AIRLINES', 'AIRWAYS', 'AVIATION', 'FLY', 'JET ', 'JETBLUE', 'JET2', 'CONDOR', 'LUFTHANSA', 'UNITED', 'DELTA',


### PR DESCRIPTION
## Summary
- update the itinerary converter to detect marketing carrier lines even when extra text like "operated by" is present
- add guards that treat aircraft/equipment rows as non-flight data so tokens such as "RJ 900" or "A320neo" are ignored
- harden airline-name heuristics in both the converter and ITA text extraction to exclude equipment keywords

## Testing
- node manual script converting the provided SAS itinerary


------
https://chatgpt.com/codex/tasks/task_e_68cf2623ec6483269ac0e9a409c1faaf