### PR TITLE
Add Matrix itinerary button SPA support and stacking fix

### DIFF
--- a/content.css
+++ b/content.css
@@ -28,7 +28,7 @@
   right:16px;
   left:auto;
   gap:6px;
-  z-index:10;
+  z-index:2147483002;
   pointer-events:auto;
 }
 


### PR DESCRIPTION
## Summary
- wrap Matrix SPA navigation updates so itinerary buttons render after pushState and replaceState
- broaden itinerary root detection to cover “Itinerary” sections and prefer the main detail column
- raise the Matrix inline button z-index so the pill stays visible above local stacking contexts

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cf2a3337a08326be3d3329049779a4