### PR TITLE
Add United alias for flight parsing

### DIFF
--- a/airlines.js
+++ b/airlines.js
@@ -4,6 +4,7 @@ const AIRLINE_CODES = {
     'DELTA AIR LINES': 'DL',
     'DELTA': 'DL',
     'UNITED AIRLINES': 'UA',
+    'UNITED': 'UA',
     'SOUTHWEST AIRLINES': 'WN',
     'AIR CANADA': 'AC',
     'ALASKA AIRLINES': 'AS',


### PR DESCRIPTION
## Summary
- add the missing "United" airline name mapping to the airline code list so United-branded flight legs are detected during parsing

## Testing
- no automated tests provided

------
https://chatgpt.com/codex/tasks/task_e_68d01f8848b48326a2dd87a31fd184b0