### PR TITLE
Fix multi-city *I formatting and add ITA Airways code

### DIFF
--- a/airlines.js
+++ b/airlines.js
@@ -54,6 +54,8 @@ const AIRLINE_CODES = {
     'AEROFLOT': 'SU',
     'AIR EUROPA': 'UX',
     'ALITALIA': 'AZ',
+    'ITA AIRWAYS': 'AZ',
+    'ITA AIRWAYS S.P.A.': 'AZ',
     'AUSTRIAN AIRLINES': 'OS',
     'BRUSSELS AIRLINES': 'SN',
     'FINNAIR': 'AY',


### PR DESCRIPTION
## Summary
- simplify the *I formatter to emit per-segment connection indicators and drop leading zero padding on times so multi-city itineraries match expected output
- add mappings for “ITA Airways” names so the converter emits AZ flight designators

## Testing
- node - <<'NODE' ... (convert sample Air Canada/SWISS itinerary)
- node - <<'NODE' ... (convert sample ITA Airways itinerary)


------
https://chatgpt.com/codex/tasks/task_e_68d046bb869c83268ab518b7deaac470