### PR TITLE
Fix missing status separator in segment formatting

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -621,8 +621,9 @@
       const bookingClass = (s.bookingClass || opts.bookingClass || '').toUpperCase();
       const flightField = formatFlightDesignator(s.airlineCode, s.number, bookingClass);
       const dateField = formatDateField(s.depDate, s.depDOW);
-      const indicator = idx < segs.length - 1 ? '*' : ' ';
-      const cityField = `${s.depAirport}${s.arrAirport}${indicator}${opts.segmentStatus}`.trim();
+      const status = (opts.segmentStatus || '').trim();
+      const indicator = status ? '*' : '';
+      const cityField = `${s.depAirport}${s.arrAirport}${indicator}${status}`.trim();
       const depTime = formatGdsTime(s.depGDS);
       const arrTime = formatGdsTime(s.arrGDS);
 


### PR DESCRIPTION
## Summary
- ensure *I output always includes the separator before the segment status when formatting city pairs

## Testing
- npx web-ext lint

------
https://chatgpt.com/codex/tasks/task_e_68d04c9005148326ae5341d0e8898689