### PR TITLE
Fix multi-city availability grouping and journey buttons

### DIFF
--- a/content.js
+++ b/content.js
@@ -427,7 +427,17 @@
             }
             converted = window.convertTextToI(raw, convertOpts);
           }else{
-            converted = window.convertTextToAvailability(raw, { direction });
+            const availOpts = { direction };
+            if(Array.isArray(config.segmentRange) && config.segmentRange.length === 2){
+              availOpts.segmentRange = [
+                Number(config.segmentRange[0]),
+                Number(config.segmentRange[1])
+              ];
+            }
+            if(typeof config.journeyIndex === 'number'){
+              availOpts.journeyIndex = config.journeyIndex;
+            }
+            converted = window.convertTextToAvailability(raw, availOpts);
           }
         } catch (parseErr) {
           console.error('Conversion failed:', parseErr);


### PR DESCRIPTION
## Summary
- pass journey index and segment ranges to availability conversions so multi-city buttons render correctly
- derive and merge journey groups based on date gaps to cluster nearby segments before generating commands
- allow availability conversion to target specific journey ranges using peekSegments results

## Testing
- node - <<'NODE' # verified multi-city availability grouping
- node - <<'NODE' # verified round-trip availability parsing


------
https://chatgpt.com/codex/tasks/task_e_68d058eed6d08326bbe0b36fe172244a