### PR TITLE
Add VI* converter to popup

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -6,7 +6,8 @@
   <style>
     body{ font: 14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:16px; color:#111;}
     label{ display:block; margin:10px 0 4px; font-weight:600; }
-    input[type="text"]{ width:120px; padding:6px 8px; border:1px solid #c7c7c7; border-radius:8px; font-size:14px; }
+    input[type="text"],
+    input[type="number"]{ width:120px; padding:6px 8px; border:1px solid #c7c7c7; border-radius:8px; font-size:14px; box-sizing:border-box; }
     small{ color:#666; }
     .row{ display:flex; gap:12px; align-items:center; }
     button{ margin-top:12px; padding:8px 12px; border-radius:8px; border:1px solid #c7c7c7; background:#fff; cursor:pointer; font-weight:600; }
@@ -14,6 +15,17 @@
     .toggle{ display:flex; align-items:center; gap:8px; margin:18px 0 4px; font-weight:600; }
     .toggle input{ width:auto; margin:0; }
     .toggle-help{ display:block; margin-left:26px; margin-top:-2px; font-size:12px; color:#666; }
+    textarea{ width:100%; min-height:140px; padding:8px 10px; border:1px solid #c7c7c7; border-radius:8px; box-sizing:border-box; font: 13px/1.5 "SFMono-Regular","Consolas","Liberation Mono",monospace; resize:vertical; }
+    textarea[readonly]{ background:#f8f8f8; color:#222; }
+    .converter{ margin-top:22px; padding-top:16px; border-top:1px solid #e6e6e6; }
+    .converter .row{ margin-bottom:4px; }
+    .converter-actions{ display:flex; gap:10px; align-items:center; margin:12px 0; }
+    .converter-actions button{ margin-top:0; }
+    .year-input{ width:110px; }
+    .convert-status{ font-size:12px; margin-bottom:8px; color:#0a7; display:none; }
+    .convert-error{ font-size:12px; margin-bottom:8px; color:#c0392b; display:none; }
+    .converter small{ display:block; margin-top:-6px; margin-bottom:10px; color:#888; }
+    #copyBtn:disabled{ opacity:0.5; cursor:default; }
   </style>
 </head>
 <body>
@@ -31,7 +43,27 @@
   </div>
   <label class="toggle"><input id="enableDirections" type="checkbox" /> Show OB / IB buttons</label>
   <small class="toggle-help">Adds inbound and outbound copy buttons next to *I.</small>
-  <button id="saveBtn">Save</button><span id="ok" class="ok">Saved</span>
+  <button id="saveBtn" type="button">Save</button><span id="ok" class="ok">Saved</span>
+
+  <div class="converter">
+    <label for="viInput">VI* itinerary</label>
+    <textarea id="viInput" placeholder="Paste Sabre VI* output here"></textarea>
+    <div class="row">
+      <div>
+        <label for="yearOverride">Start year (optional)</label>
+        <input id="yearOverride" class="year-input" type="number" min="1900" max="2100" placeholder="2025" />
+        <small>Used to compute day-of-week codes.</small>
+      </div>
+    </div>
+    <div class="converter-actions">
+      <button id="convertBtn" type="button">Convert to *I</button>
+      <button id="copyBtn" type="button" disabled>Copy</button>
+    </div>
+    <div id="convertStatus" class="convert-status"></div>
+    <div id="convertError" class="convert-error"></div>
+    <label for="iOutput">*I result</label>
+    <textarea id="iOutput" readonly placeholder="Converted *I output will appear here"></textarea>
+  </div>
 
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1,25 +1,292 @@
 (() => {
+  'use strict';
+
+  const MONTH_INDEX = { JAN:0, FEB:1, MAR:2, APR:3, MAY:4, JUN:5, JUL:6, AUG:7, SEP:8, OCT:9, NOV:10, DEC:11 };
+  const MONTH_NAMES = ['JAN','FEB','MAR','APR','MAY','JUN','JUL','AUG','SEP','OCT','NOV','DEC'];
+  const DOW_CHARS = ['S','M','T','W','Q','F','J'];
+
   const booking = document.getElementById('bookingClass');
-  const status  = document.getElementById('segmentStatus');
+  const status = document.getElementById('segmentStatus');
   const enableDirections = document.getElementById('enableDirections');
-  const okEl    = document.getElementById('ok');
+  const okEl = document.getElementById('ok');
   const saveBtn = document.getElementById('saveBtn');
 
-  chrome.storage.sync.get(['bookingClass','segmentStatus','enableDirectionButtons'], (res)=>{
-    booking.value = (res.bookingClass || 'J').toUpperCase().slice(0,1);
-    status.value  = (res.segmentStatus || 'SS1').toUpperCase().slice(0,3);
+  const viInput = document.getElementById('viInput');
+  const yearInput = document.getElementById('yearOverride');
+  const convertBtn = document.getElementById('convertBtn');
+  const copyBtn = document.getElementById('copyBtn');
+  const outputEl = document.getElementById('iOutput');
+  const convertErrorEl = document.getElementById('convertError');
+  const convertStatusEl = document.getElementById('convertStatus');
+
+  chrome.storage.sync.get(['bookingClass','segmentStatus','enableDirectionButtons'], (res) => {
+    booking.value = sanitizeBookingClass(res.bookingClass);
+    status.value = sanitizeSegmentStatus(res.segmentStatus);
     enableDirections.checked = !!res.enableDirectionButtons;
   });
 
-  saveBtn.addEventListener('click', ()=>{
-    const bc = (booking.value || 'J').toUpperCase().slice(0,1);
-    const ss = (status.value || 'SS1').toUpperCase().slice(0,3);
+  saveBtn.addEventListener('click', () => {
+    const bc = sanitizeBookingClass(booking.value);
+    const ss = sanitizeSegmentStatus(status.value);
     const enableDir = !!enableDirections.checked;
-    chrome.storage.sync.set({ bookingClass: bc, segmentStatus: ss, enableDirectionButtons: enableDir }, ()=>{
-      okEl.textContent = 'saved';
+    chrome.storage.sync.set({ bookingClass: bc, segmentStatus: ss, enableDirectionButtons: enableDir }, () => {
+      okEl.textContent = 'Saved';
       okEl.style.display = 'inline-block';
-      // close after a short confirmation
       setTimeout(() => { window.close(); }, 600);
     });
   });
+
+  convertBtn.addEventListener('click', () => {
+    clearMessages();
+    copyBtn.disabled = true;
+    const raw = (viInput.value || '').trim();
+    if(!raw){
+      showError('Paste VI* text first.');
+      outputEl.value = '';
+      return;
+    }
+    const options = {
+      bookingClass: sanitizeBookingClass(booking.value),
+      segmentStatus: sanitizeSegmentStatus(status.value),
+      baseYear: parseYear(yearInput.value)
+    };
+    try {
+      const result = convertViToI(raw, options);
+      outputEl.value = result;
+      if(result){
+        copyBtn.disabled = false;
+        const lines = result.split('\n');
+        showStatus(`Converted ${lines.length} segment${lines.length === 1 ? '' : 's'}.`);
+      } else {
+        showError('No segments found in VI* text.');
+      }
+    } catch(err){
+      outputEl.value = '';
+      showError(err && err.message ? err.message : 'Could not convert itinerary.');
+    }
+  });
+
+  copyBtn.addEventListener('click', () => {
+    const text = (outputEl.value || '').trim();
+    if(!text){
+      return;
+    }
+    navigator.clipboard.writeText(text).then(() => {
+      showStatus('Copied to clipboard.');
+    }).catch(() => {
+      showError('Copy failed.');
+    });
+  });
+
+  viInput.addEventListener('input', clearMessages);
+  yearInput.addEventListener('input', clearMessages);
+
+  function sanitizeBookingClass(value){
+    const clean = (value || 'J').toUpperCase().replace(/[^A-Z]/g,'').slice(0,1);
+    return clean || 'J';
+  }
+
+  function sanitizeSegmentStatus(value){
+    const clean = (value || 'SS1').toUpperCase().replace(/[^A-Z0-9]/g,'').slice(0,3);
+    return clean || 'SS1';
+  }
+
+  function parseYear(value){
+    const year = parseInt(value, 10);
+    if(Number.isFinite(year) && year >= 1900 && year <= 2100){
+      return year;
+    }
+    return null;
+  }
+
+  function clearMessages(){
+    convertErrorEl.style.display = 'none';
+    convertErrorEl.textContent = '';
+    convertStatusEl.style.display = 'none';
+    convertStatusEl.textContent = '';
+    copyBtn.disabled = true;
+  }
+
+  function showError(message){
+    convertStatusEl.style.display = 'none';
+    convertStatusEl.textContent = '';
+    convertErrorEl.textContent = message;
+    convertErrorEl.style.display = 'block';
+  }
+
+  function showStatus(message){
+    convertErrorEl.style.display = 'none';
+    convertErrorEl.textContent = '';
+    convertStatusEl.textContent = message;
+    convertStatusEl.style.display = 'block';
+  }
+
+  function convertViToI(rawText, options){
+    const opts = options || {};
+    const segments = extractSegments(rawText);
+    if(segments.length === 0){
+      throw new Error('No segments found in VI* text.');
+    }
+    assignSegmentDates(segments, opts.baseYear);
+    return formatSegments(segments, opts);
+  }
+
+  function extractSegments(rawText){
+    const segments = [];
+    if(!rawText) return segments;
+    const lines = rawText.replace(/\r\n/g, '\n').split('\n');
+    for(const line of lines){
+      if(!/^\s*\d+\s+/.test(line || '')) continue;
+      const tokens = line.trim().split(/\s+/);
+      if(tokens.length < 7) continue;
+
+      const indexToken = tokens.shift();
+      if(!/^\d+$/.test(indexToken)) continue;
+
+      const flightTokens = [];
+      while(tokens.length && !/^\d{1,2}[A-Z]{3}$/i.test(tokens[0])){
+        flightTokens.push(tokens.shift());
+      }
+      if(flightTokens.length === 0) continue;
+      const flightJoined = flightTokens.join('');
+      const flightMatch = flightJoined.match(/^([A-Z0-9]{2})(\*?)([A-Z0-9]+)$/i);
+      if(!flightMatch) continue;
+
+      const airlineCode = flightMatch[1].toUpperCase();
+      const flightNumber = flightMatch[3].toUpperCase();
+
+      if(tokens.length === 0) continue;
+      const dateToken = (tokens.shift() || '').toUpperCase();
+      const dateMatch = dateToken.match(/^(\d{1,2})([A-Z]{3})$/);
+      if(!dateMatch) continue;
+      const day = parseInt(dateMatch[1], 10);
+      const monthKey = dateMatch[2];
+      if(!Object.prototype.hasOwnProperty.call(MONTH_INDEX, monthKey)) continue;
+      const monthIndex = MONTH_INDEX[monthKey];
+
+      if(tokens.length < 4) continue;
+      const depAirport = (tokens.shift() || '').toUpperCase();
+      const arrAirport = (tokens.shift() || '').toUpperCase();
+      if(!/^[A-Z]{3}$/.test(depAirport) || !/^[A-Z]{3}$/.test(arrAirport)) continue;
+
+      const depTimeToken = tokens.shift() || '';
+      const arrTimeToken = tokens.shift() || '';
+      const depParsed = parseTimeToken(depTimeToken);
+      const arrParsed = parseTimeToken(arrTimeToken);
+
+      segments.push({
+        airlineCode,
+        flightNumber,
+        depAirport,
+        arrAirport,
+        depDay: day,
+        depMonth: monthIndex,
+        depTime: depParsed.time,
+        arrTime: arrParsed.time,
+        arrOffset: arrParsed.offset
+      });
+    }
+    return segments;
+  }
+
+  function parseTimeToken(token){
+    const trimmed = (token || '').trim();
+    if(!trimmed){
+      return { time: '', offset: 0 };
+    }
+    const offsetMatch = trimmed.match(/(?:¥|\+)(\d+)/i);
+    const offset = offsetMatch ? parseInt(offsetMatch[1], 10) || 0 : 0;
+    const base = trimmed.replace(/(?:¥|\+)\s*\d+/gi, '');
+    const cleaned = base.replace(/[^0-9AP]/gi, '');
+    const match = cleaned.match(/(\d{3,4})([AP])?/i);
+    if(!match){
+      return { time: cleaned.toUpperCase(), offset };
+    }
+    const time = match[1] + (match[2] ? match[2].toUpperCase() : '');
+    return { time, offset };
+  }
+
+  function assignSegmentDates(segments, baseYear){
+    if(segments.length === 0) return;
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    let workingYear = Number.isFinite(baseYear) ? baseYear : now.getFullYear();
+
+    let firstDep = new Date(workingYear, segments[0].depMonth, segments[0].depDay);
+    if(!Number.isFinite(baseYear)){
+      const nextCandidate = new Date(workingYear + 1, segments[0].depMonth, segments[0].depDay);
+      if(firstDep < today && Math.abs(nextCandidate - today) < Math.abs(firstDep - today)){
+        workingYear += 1;
+        firstDep = nextCandidate;
+      }
+    }
+    applyDatesToSegment(segments[0], firstDep);
+    let lastArrMidnight = toMidnight(segments[0].arrDateObj);
+
+    for(let i = 1; i < segments.length; i++){
+      let candidate = new Date(workingYear, segments[i].depMonth, segments[i].depDay);
+      while(candidate < lastArrMidnight){
+        workingYear += 1;
+        candidate = new Date(workingYear, segments[i].depMonth, segments[i].depDay);
+      }
+      applyDatesToSegment(segments[i], candidate);
+      const arrMidnight = toMidnight(segments[i].arrDateObj);
+      if(arrMidnight > lastArrMidnight){
+        lastArrMidnight = arrMidnight;
+      }
+    }
+  }
+
+  function applyDatesToSegment(segment, depDate){
+    segment.depDateObj = depDate;
+    segment.depDateString = formatDatePart(depDate);
+    segment.depDow = DOW_CHARS[depDate.getDay()] || '';
+    const arrival = new Date(depDate.getTime());
+    arrival.setDate(arrival.getDate() + (segment.arrOffset || 0));
+    segment.arrDateObj = arrival;
+    segment.arrDateString = formatDatePart(arrival);
+    segment.arrDow = DOW_CHARS[arrival.getDay()] || '';
+  }
+
+  function toMidnight(date){
+    return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  }
+
+  function formatDatePart(date){
+    const day = String(date.getDate()).padStart(2, '0');
+    const mon = MONTH_NAMES[date.getMonth()] || '';
+    return `${day}${mon}`;
+  }
+
+  function formatSegments(segments, options){
+    const bookingClass = sanitizeBookingClass(options.bookingClass);
+    const segmentStatus = sanitizeSegmentStatus(options.segmentStatus);
+    const lines = [];
+    for(let i = 0; i < segments.length; i++){
+      const seg = segments[i];
+      const segNumber = String(i + 1).padStart(2, ' ');
+      const flightField = formatFlightField(seg.airlineCode, seg.flightNumber, bookingClass);
+      const dateField = seg.depDow ? `${seg.depDateString} ${seg.depDow}` : seg.depDateString;
+      const cityField = segmentStatus
+        ? `${seg.depAirport}${seg.arrAirport}*${segmentStatus}`
+        : `${seg.depAirport}${seg.arrAirport}`;
+      const parts = [segNumber, flightField, dateField, cityField];
+      if(seg.depTime){ parts.push(seg.depTime); }
+      if(seg.arrTime){ parts.push(seg.arrTime); }
+      if(seg.arrOffset > 0){
+        const arrField = seg.arrDow ? `${seg.arrDateString} ${seg.arrDow}` : seg.arrDateString;
+        parts.push(arrField);
+      }
+      parts.push(`/DC${seg.airlineCode}`);
+      parts.push('/E');
+      lines.push(parts.join(' '));
+    }
+    return lines.join('\n');
+  }
+
+  function formatFlightField(airlineCode, flightNumber, bookingClass){
+    const num = flightNumber || '';
+    const base = num.length < 4 ? `${airlineCode} ${num}` : `${airlineCode}${num}`;
+    return `${base}${bookingClass}`;
+  }
 })();


### PR DESCRIPTION
## Summary
- expand the popup UI with a dedicated VI* input area, optional year override, and convert/copy controls for producing *I strings.
- add standalone VI* parsing, date inference, and formatting logic in the popup script, plus status and clipboard feedback for conversions.

## Testing
- node - <<'NODE' ...

------
https://chatgpt.com/codex/tasks/task_e_68d05b034b588326a5d62a5be14b8063