### PR TITLE
Fix availability copying for journey buttons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,8 @@ UI logic:
 If isMultiCity or journeys.length > 1: replace OB/IB with per-journey buttons labeled
 # {origin}-{dest} (e.g., 1 MIA-VCE, 2 NAP-MIA).
 
+Journey and direction buttons (OB/IB) must copy availability commands, not *I strings.
+
 Clicking a journey pill copies only that journey’s output (availability or *I for that segment range).
 
 5) Parsing engine (tokenizer/state machine)

--- a/content.js
+++ b/content.js
@@ -273,7 +273,8 @@
       label: '*I',
       title: 'Copy itinerary option details',
       ariaLabel: 'Copy itinerary option details to clipboard',
-      direction: 'all'
+      direction: 'all',
+      copyKind: 'itinerary'
     };
 
     let rawText = '';
@@ -326,7 +327,8 @@
           direction: 'all',
           segmentRange: [start, end],
           journeyIndex: idx,
-          variant: 'journey'
+          variant: 'journey',
+          copyKind: 'availability'
         });
         journeySignatureParts.push(`${start}-${end}-${origin || ''}-${dest || ''}-${indexHint}`);
       });
@@ -336,14 +338,16 @@
         label: 'OB',
         title: 'Copy outbound segments',
         ariaLabel: 'Copy outbound segments to clipboard',
-        direction: 'outbound'
+        direction: 'outbound',
+        copyKind: 'availability'
       });
       configs.push({
         key: 'ib',
         label: 'IB',
         title: 'Copy inbound segments',
         ariaLabel: 'Copy inbound segments to clipboard',
-        direction: 'inbound'
+        direction: 'inbound',
+        copyKind: 'availability'
       });
     }
 
@@ -412,9 +416,10 @@
           segmentStatus: SETTINGS.segmentStatus
         };
         const direction = config.direction || 'all';
+        const copyKind = config.copyKind || (direction === 'all' ? 'itinerary' : 'availability');
         let converted;
         try {
-          if(direction === 'all'){
+          if(copyKind === 'itinerary'){
             const convertOpts = Object.assign({}, baseOpts);
             if(Array.isArray(config.segmentRange) && config.segmentRange.length === 2){
               convertOpts.segmentRange = [


### PR DESCRIPTION
## Summary
- ensure journey and direction pills request availability conversions instead of *I output when appropriate
- document in AGENTS.md that multi-journey and OB/IB buttons must copy availability commands

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d06459836083269de8b7e59bc50b84