### PR TITLE
Fix multi-city journey deduplication

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -487,6 +487,19 @@
             const nextDow = headerRef.dow || prevDow || '';
             currentDate = { day: headerRef.day, mon: headerRef.mon, dow: nextDow };
           }
+          if(journeys && currentJourney && currentJourney.explicit && journeyInfo.index != null){
+            const currentIndex = (typeof currentJourney.indexHint === 'number' && Number.isFinite(currentJourney.indexHint))
+              ? currentJourney.indexHint
+              : null;
+            if(currentIndex != null && currentIndex === journeyInfo.index){
+              if(headerRef){
+                currentJourney.headerDate = { ...headerRef };
+              } else if(!currentJourney.headerDate && currentDate){
+                currentJourney.headerDate = { ...currentDate };
+              }
+              continue;
+            }
+          }
           startJourney({ explicit: true, indexHint: journeyInfo.index != null ? Number(journeyInfo.index) : null, headerDate: headerRef || currentDate });
           continue;
         }


### PR DESCRIPTION
## Summary
- prevent repeated Flight headers from spawning separate journeys while parsing itineraries
- ensure multi-city pills map to the true journey ranges across Kayak and ITA layouts

## Testing
- node - <<'NODE' ... (sanity check that repeated Flight headers still yield two journeys)


------
https://chatgpt.com/codex/tasks/task_e_68d0699564c88326821511924df119ba