### PR TITLE
Honor direction toggle for multi-city leg buttons

### DIFF
--- a/content.js
+++ b/content.js
@@ -400,7 +400,7 @@
     const journeys = preview && Array.isArray(preview.journeys) ? preview.journeys : [];
     const segments = preview && Array.isArray(preview.segments) ? preview.segments : [];
     const multiCity = !!(preview && preview.isMultiCity && journeys.length > 0);
-    const showJourneyButtons = multiCity && !IS_ITA;
+    const showJourneyButtons = multiCity && !IS_ITA && SETTINGS.enableDirectionButtons;
 
     const journeySignatureParts = [];
     if(showJourneyButtons){


### PR DESCRIPTION
## Summary
- gate multi-city journey buttons behind the existing direction toggle so they disappear when it is disabled

## Testing
- no tests (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d17441caec8326b81f4f5a103eab66