### PR TITLE
Relocate Kayak pills inside itinerary details

### DIFF
--- a/content.css
+++ b/content.css
@@ -22,6 +22,19 @@
   position:relative;
 }
 
+.kayak-copy-inline-slot{
+  position:relative;
+  min-height:56px;
+  margin:4px 0 12px;
+  display:block;
+}
+
+.kayak-copy-inline-slot .kayak-copy-btn-group--ita{
+  top:8px;
+  right:12px;
+  left:auto;
+}
+
 .kayak-copy-btn-group.kayak-copy-btn-group--ita{
   position:absolute;
   top:12px;


### PR DESCRIPTION
## Summary
- add heuristics to find the Kayak itinerary details container and reuse inline hosts when falling back to inline placement
- insert a dedicated inline slot before the itinerary details so the pill group renders just above the expanded itinerary

## Testing
- not run (extension content script change)


------
https://chatgpt.com/codex/tasks/task_e_68d18b4b67bc8326bd2139f8fbe2ab02