### PR TITLE
Fix availability buttons for connecting itineraries

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1159,6 +1159,12 @@
       let gap = 0;
       if(prevOrdinal != null && nextOrdinal != null){
         gap = nextOrdinal - prevOrdinal;
+        if(gap >= ORDINAL_YEAR_SPAN){
+          const normalizedGap = gap % ORDINAL_YEAR_SPAN;
+          if(normalizedGap <= JOURNEY_DATE_GAP_THRESHOLD){
+            gap = normalizedGap;
+          }
+        }
       }
       if(gap <= JOURNEY_DATE_GAP_THRESHOLD){
         if(entry.endIdx > prev.endIdx){


### PR DESCRIPTION
## Summary
- normalize the journey merge gap calculation so same-day segments remain part of one journey
- ensure connecting itineraries surface availability buttons for full origin-destination journeys instead of per-leg splits

## Testing
- node /workspace/test_avail.js

------
https://chatgpt.com/codex/tasks/task_e_68d19199cc5c8326bf383c11aff7b670