### PR TITLE
Improve cabin detection, journey pills, and popup automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,3 +218,9 @@ Multi-city text from Kayak (bottom-right → top-left copy order) parses consist
 No regressions in ITA Matrix placements, styling, or parsing.
 
 Tip: If DOM shapes drift, prefer resilient heuristics (times + airports + presence of Select) over brittle classnames, and keep ad/rail filters strict.
+
+11) Popup specifics
+
+- The popup auto-converts VI* text on input and attempts an automatic clipboard write (guarded by the `autoCopyOnConvert` flag). Respect the toggle stored in sync storage.
+- Manual booking class edits must set `bookingClassLocked` to `true`; the “Restore auto cabin detection” action clears that flag so content scripts can resume detection.
+- The legacy start-year field is gone; date logic infers years automatically. Do not reintroduce the field or depend on manual year entry.

--- a/airlines.js
+++ b/airlines.js
@@ -74,6 +74,8 @@ const AIRLINE_CODES = {
     'EASYJET AIRLINE COMPANY': 'U2',
     'TURKISH AIRLINES': 'TK',
     'TURKISH': 'TK',
+    'THY': 'TK',
+    'TURK HAVA YOLLARI': 'TK',
     'IBERIA': 'IB',
     'IBERIA AIRLINES': 'IB',
     'SWISS INTERNATIONAL AIR LINES': 'LX',
@@ -104,6 +106,9 @@ const AIRLINE_CODES = {
     'EURO WINGS': 'EW',
     'LOT POLISH AIRLINES': 'LO',
     'LOT POLISH': 'LO',
+    'LOT POLSKIE LINIE LOTNICZE': 'LO', // alias w/out dash
+    'LOT – POLSKIE LINIE LOTNICZE': 'LO', // en dash variant observed on EU locales
+    'LOT - POLSKIE LINIE LOTNICZE': 'LO',
     'NORWEGIAN AIR SHUTTLE': 'DY',
     'NORWEGIAN': 'DY',
     'NORWEGIAN AIR': 'DY',
@@ -119,6 +124,55 @@ const AIRLINE_CODES = {
     'VUELING AIRLINES': 'VY',
     'WIZZ AIR': 'W6',
     'WIZZ': 'W6',
+    'WIZZ AIR MALTA': 'W4',
+    'PEGASUS AIRLINES': 'PC',
+    'PEGASUS': 'PC',
+    'PEGASUS HAVA YOLLARI': 'PC',
+    'PEGASUS HAVA YOLLARI A S': 'PC',
+    'PEGASUS HAVA YOLLARI A.S.': 'PC',
+    'PEGASUS HAVA YOLLARI A.S': 'PC',
+    'PEGASUS HAVA TASIMACILIGI A S': 'PC',
+    'PEGASUS HAVA TASIMACILIGI A.S.': 'PC',
+    'PEGASUS HAVA TASIMACILIGI A.S': 'PC',
+    'PEGASUS HAVA TASIMACILIGI': 'PC',
+    'PEGASUS HAVA TASIMACILIGI ANONIM SIRKETI': 'PC',
+    'PEGASUS HAVA YOLLARI ANONIM SIRKETI': 'PC',
+    'PEGASUS ASIA': 'PC',
+    'PEGASUS ASIA AIRLINES': 'PC',
+    'PEGASUS HAVAYOLLARI': 'PC',
+    'PEGASUS HAVAYOLLARI A.S.': 'PC',
+    'PEGASUS HAVAYOLLARI A.S': 'PC',
+    'PEGASUS HAVAYOLLARI A S': 'PC',
+    'PEGASUS HAVAYOLLARI ANONIM SIRKETI': 'PC',
+    'PEGASUS AIRLINES AS': 'PC',
+    'PEGASUS AIRLINES A.S.': 'PC',
+    'TAROM': 'RO',
+    'TAROM ROMANIAN AIR TRANSPORT': 'RO',
+    'AEGEAN AIRLINES': 'A3',
+    'AEGEAN AIR': 'A3',
+    'AIR SERBIA': 'JU',
+    'AIRSERBIA': 'JU',
+    'AIR SERBIA A.D.': 'JU',
+    'AIR SERBIA JSC': 'JU',
+    'ANADOLUJET': 'TK',
+    'ANADOLU JET': 'TK',
+    'ANADOLUJET AIRLINES': 'TK',
+    'AJET': 'TK',
+    'A JET': 'TK',
+    'HISKY': 'H4',
+    'HI SKY': 'H4',
+    'HISKY EUROPE': 'H4',
+    'FLYONE': '5F',
+    'FLY ONE': '5F',
+    'AIR ASTANA': 'KC',
+    'AIR ASTANA JSC': 'KC',
+    'UZBEKISTAN AIRWAYS': 'HY',
+    'UZBEKISTAN AIR': 'HY',
+    'AZERBAIJAN AIRLINES': 'J2',
+    'AZERBAIJAN AIRLINES (AZAL)': 'J2',
+    'AZAL': 'J2',
+    'GEORGIAN AIRWAYS': 'A9',
+    'AIRZENA': 'A9',
     'TUI FLY': 'X3',
     'TUIFLY': 'X3',
     'TUI FLY DEUTSCHLAND': 'X3',
@@ -211,3 +265,41 @@ const AIRLINE_CODES = {
     'ROYAL AIR MAROC AIRLINES': 'AT',
     'RAM': 'AT'
 };
+
+// Normalized lookup helpers for airline aliases with punctuation/diacritics
+function normalizeAirlineNameKey(name){
+    if(!name && name !== 0) return '';
+    let value = String(name);
+    if(typeof value.normalize === 'function'){
+        value = value.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+    }
+    value = value.toUpperCase().replace(/[^A-Z0-9]+/g, ' ').trim().replace(/\s+/g, ' ');
+    return value;
+}
+
+const AIRLINE_NORMALIZED_CODES = {};
+Object.keys(AIRLINE_CODES).forEach((key) => {
+    const normalized = normalizeAirlineNameKey(key);
+    if(normalized && !Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, normalized)){
+        AIRLINE_NORMALIZED_CODES[normalized] = AIRLINE_CODES[key];
+    }
+});
+
+function lookupAirlineCodeByName(name){
+    if(!name && name !== 0) return null;
+    const directKey = String(name).trim().toUpperCase();
+    if(directKey && Object.prototype.hasOwnProperty.call(AIRLINE_CODES, directKey)){
+        return AIRLINE_CODES[directKey];
+    }
+    const normalized = normalizeAirlineNameKey(name);
+    if(normalized && Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, normalized)){
+        return AIRLINE_NORMALIZED_CODES[normalized];
+    }
+    return null;
+}
+
+if(typeof window !== 'undefined'){
+    window.lookupAirlineCodeByName = lookupAirlineCodeByName;
+    window.normalizeAirlineNameKey = normalizeAirlineNameKey;
+    window.AIRLINE_NORMALIZED_CODES = AIRLINE_NORMALIZED_CODES;
+}

--- a/content.css
+++ b/content.css
@@ -49,7 +49,7 @@
   flex-wrap:wrap;
   justify-content:flex-end;
   gap:6px;
-  align-items:flex-start;
+  align-items:center;
 }
 
 .kayak-copy-btn-group--ita.kayak-copy-btn-group--multi{
@@ -171,22 +171,41 @@
 
 .kayak-copy-btn--journey{
   width:auto;
-  min-width:54px;
+  min-width:0;
   height:32px;
-  padding:0 14px;
+  padding:0 16px;
   border-radius:999px;
   font-size:12px;
   letter-spacing:0;
+  overflow:visible;
 }
 
 .kayak-copy-btn--journey .pill-text{
   font-size:12px;
   letter-spacing:0;
   white-space:nowrap;
+  padding:0 2px;
 }
 
 .kayak-copy-btn--journey.is-copied::after{
   border-radius:999px;
+}
+
+.kayak-copy-cabin-hint{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:2px 8px;
+  margin-right:6px;
+  margin-bottom:4px;
+  border-radius:999px;
+  background:rgba(16,26,42,.85);
+  color:#fff;
+  font:600 10px/1 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+  pointer-events:none;
+  flex-shrink:0;
 }
 
 @keyframes kayak-copy-ping{

--- a/popup.html
+++ b/popup.html
@@ -21,11 +21,18 @@
     .converter .row{ margin-bottom:4px; }
     .converter-actions{ display:flex; gap:10px; align-items:center; margin:12px 0; }
     .converter-actions button{ margin-top:0; }
-    .year-input{ width:110px; }
     .convert-status{ font-size:12px; margin-bottom:8px; color:#0a7; display:none; }
     .convert-error{ font-size:12px; margin-bottom:8px; color:#c0392b; display:none; }
     .converter small{ display:block; margin-top:-6px; margin-bottom:10px; color:#888; }
     #copyBtn:disabled{ opacity:0.5; cursor:default; }
+    .auto-detect{ display:flex; align-items:center; gap:12px; margin:6px 0 10px; }
+    .auto-detect__note{ font-size:12px; color:#555; flex:1; }
+    .link-btn{ border:none; background:none; padding:0; color:#0a7; font-size:12px; font-weight:600; cursor:pointer; text-decoration:underline; }
+    .link-btn:disabled{ opacity:0.6; cursor:default; text-decoration:none; }
+    .converter-toggle{ display:flex; flex-direction:column; align-items:flex-start; gap:2px; margin:12px 0 4px; font-weight:600; }
+    .converter-toggle label{ display:flex; align-items:center; gap:8px; margin:0; font-weight:600; }
+    .converter-toggle input{ width:auto; margin:0; }
+    .converter-toggle small{ font-weight:400; font-size:12px; color:#666; margin:0; }
   </style>
 </head>
 <body>
@@ -41,6 +48,10 @@
       <small>3 chars</small>
     </div>
   </div>
+  <div class="auto-detect">
+    <span id="bookingStatusNote" class="auto-detect__note"></span>
+    <button id="restoreAutoBtn" type="button" class="link-btn">Restore auto cabin detection</button>
+  </div>
   <label class="toggle"><input id="enableDirections" type="checkbox" /> Show OB / IB buttons</label>
   <small class="toggle-help">Adds inbound and outbound copy buttons next to *I.</small>
   <button id="saveBtn" type="button">Save</button><span id="ok" class="ok">Saved</span>
@@ -48,12 +59,9 @@
   <div class="converter">
     <label for="viInput">VI* itinerary</label>
     <textarea id="viInput" placeholder="Paste Sabre VI* output here"></textarea>
-    <div class="row">
-      <div>
-        <label for="yearOverride">Start year (optional)</label>
-        <input id="yearOverride" class="year-input" type="number" min="1900" max="2100" placeholder="2025" />
-        <small>Used to compute day-of-week codes.</small>
-      </div>
+    <div class="converter-toggle">
+      <label for="autoCopyToggle"><input id="autoCopyToggle" type="checkbox" /> Auto-copy result</label>
+      <small>Automatically copies the converted *I after parsing.</small>
     </div>
     <div class="converter-actions">
       <button id="convertBtn" type="button">Convert to *I</button>


### PR DESCRIPTION
## Summary
- expand the airline alias lookup and normalization helpers so unknown carriers default to XX instead of being dropped
- enhance converter and content logic to derive per-journey multi-city pills, surface mixed-cabin hints, and respect sticky header stacking
- overhaul the popup by removing the start-year field, auto-converting/copying VI* input, and adding an auto-copy toggle plus restore-auto-detect control

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d2130fac6483268106e9c8f557337d