### PR TITLE
Gate journey pills on toggle and add availability preview

### DIFF
--- a/content.css
+++ b/content.css
@@ -48,7 +48,7 @@
 .kayak-copy-btn-group--multi{
   flex-wrap:wrap;
   justify-content:flex-end;
-  gap:6px;
+  gap:8px;
   align-items:center;
 }
 
@@ -112,7 +112,7 @@
 }
 
 .kayak-copy-btn-group--multi .kayak-copy-btn{
-  flex-shrink:0;
+  flex-shrink:1;
 }
 
 .kayak-copy-btn-group--ita .kayak-copy-btn .pill-text{
@@ -171,20 +171,30 @@
 
 .kayak-copy-btn--journey{
   width:auto;
-  min-width:0;
+  min-width:64px;
   height:32px;
-  padding:0 16px;
+  padding:0 18px;
   border-radius:999px;
   font-size:12px;
   letter-spacing:0;
   overflow:visible;
+  max-width:240px;
 }
 
 .kayak-copy-btn--journey .pill-text{
+  position:relative;
+  inset:auto;
+  width:auto;
+  height:auto;
   font-size:12px;
   letter-spacing:0;
   white-space:nowrap;
-  padding:0 2px;
+  padding:0 6px;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  overflow:hidden;
+  text-overflow:ellipsis;
 }
 
 .kayak-copy-btn--journey.is-copied::after{

--- a/content.js
+++ b/content.js
@@ -491,6 +491,17 @@
     });
 
     cachedAvoidTop = maxBottom || 0;
+    const fallbackAvoid = (() => {
+      if(!Number.isFinite(viewHeight) || viewHeight <= 0){
+        return 72;
+      }
+      const scaled = Math.max(viewHeight * 0.16, 72);
+      const capped = Math.min(scaled, Math.max(viewHeight - 160, 72));
+      return Math.max(72, Math.round(capped));
+    })();
+    if(cachedAvoidTop < fallbackAvoid){
+      cachedAvoidTop = fallbackAvoid;
+    }
     if(highestZ != null){
       lastKnownHeaderZ = highestZ;
       const targetBase = Math.max(0, Math.min(highestZ - 2, DEFAULT_OVERLAY_BASE_Z));
@@ -759,7 +770,7 @@
     const journeys = preview && Array.isArray(preview.journeys) ? preview.journeys : [];
     const segments = preview && Array.isArray(preview.segments) ? preview.segments : [];
     const multiCity = !!(preview && preview.isMultiCity && journeys.length > 0);
-    const showJourneyButtons = multiCity;
+    const showJourneyButtons = multiCity && SETTINGS.enableDirectionButtons;
 
     const journeySignatureParts = [];
     if(showJourneyButtons){
@@ -834,7 +845,8 @@
     return {
       configs,
       signature: signaturePieces.join('::'),
-      preview
+      preview,
+      showJourneyButtons
     };
   }
 
@@ -950,8 +962,7 @@
     if(!group) return;
     const data = configData || computeButtonConfigsForCard(card);
     const inlineMode = group.dataset.inline === '1';
-    const previewMulti = !!(data && data.preview && data.preview.isMultiCity);
-    const showMulti = previewMulti;
+    const showMulti = !!(data && data.showJourneyButtons);
     group.classList.toggle('kayak-copy-btn-group--ita', inlineMode);
     group.classList.toggle('kayak-copy-btn-group--multi', showMulti);
     if(showMulti){

--- a/popup.html
+++ b/popup.html
@@ -29,10 +29,15 @@
     .auto-detect__note{ font-size:12px; color:#555; flex:1; }
     .link-btn{ border:none; background:none; padding:0; color:#0a7; font-size:12px; font-weight:600; cursor:pointer; text-decoration:underline; }
     .link-btn:disabled{ opacity:0.6; cursor:default; text-decoration:none; }
-    .converter-toggle{ display:flex; flex-direction:column; align-items:flex-start; gap:2px; margin:12px 0 4px; font-weight:600; }
-    .converter-toggle label{ display:flex; align-items:center; gap:8px; margin:0; font-weight:600; }
-    .converter-toggle input{ width:auto; margin:0; }
-    .converter-toggle small{ font-weight:400; font-size:12px; color:#666; margin:0; }
+    .availability-preview{ margin-top:16px; padding:12px 12px 10px; border:1px solid #d8d8d8; border-radius:10px; background:#f8f9fb; display:none; }
+    .availability-preview__title{ font-weight:700; margin-bottom:6px; font-size:13px; color:#0a4069; }
+    .availability-preview__list{ display:flex; flex-direction:column; gap:6px; }
+    .availability-preview__item{ display:grid; grid-template-columns:auto 1fr auto; gap:8px; align-items:center; padding:6px 8px; border-radius:8px; background:#fff; box-shadow:0 1px 2px rgba(9, 19, 33, .08); }
+    .availability-preview__label{ font-weight:600; color:#0a4069; font-size:12px; }
+    .availability-preview__command{ font:12px/1.4 "SFMono-Regular","Consolas","Liberation Mono",monospace; color:#111; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+    .availability-preview__copy{ border:none; background:#0a7; color:#fff; font-weight:600; font-size:12px; padding:6px 10px; border-radius:6px; cursor:pointer; }
+    .availability-preview__copy:disabled{ opacity:.6; cursor:default; }
+    .availability-preview__hint{ display:block; margin-top:8px; font-size:11px; color:#5a6472; }
   </style>
 </head>
 <body>
@@ -52,16 +57,17 @@
     <span id="bookingStatusNote" class="auto-detect__note"></span>
     <button id="restoreAutoBtn" type="button" class="link-btn">Restore auto cabin detection</button>
   </div>
-  <label class="toggle"><input id="enableDirections" type="checkbox" /> Show OB / IB buttons</label>
-  <small class="toggle-help">Adds inbound and outbound copy buttons next to *I.</small>
+  <label class="toggle"><input id="enableDirections" type="checkbox" /> Show availability buttons</label>
+  <small class="toggle-help">Adds outbound / inbound (and multi-city journey) availability pills next to *I.</small>
   <button id="saveBtn" type="button">Save</button><span id="ok" class="ok">Saved</span>
 
   <div class="converter">
     <label for="viInput">VI* itinerary</label>
     <textarea id="viInput" placeholder="Paste Sabre VI* output here"></textarea>
-    <div class="converter-toggle">
-      <label for="autoCopyToggle"><input id="autoCopyToggle" type="checkbox" /> Auto-copy result</label>
-      <small>Automatically copies the converted *I after parsing.</small>
+    <div id="availabilityPreview" class="availability-preview">
+      <div class="availability-preview__title">Availability commands</div>
+      <div id="availabilityList" class="availability-preview__list" role="list"></div>
+      <small class="availability-preview__hint">Generated from the VI* text — tap any command to copy it instantly.</small>
     </div>
     <div class="converter-actions">
       <button id="convertBtn" type="button">Convert to *I</button>
@@ -72,7 +78,8 @@
     <label for="iOutput">*I result</label>
     <textarea id="iOutput" readonly placeholder="Converted *I output will appear here"></textarea>
   </div>
-
+  <script src="airlines.js"></script>
+  <script src="converter.js"></script>
   <script src="popup.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- gate multi-city journey pills behind the availability toggle and push overlay pills below sticky headers
- adjust pill styling so journey labels stay inside their buttons across Kayak and Matrix
- replace the popup auto-copy toggle with an availability command preview powered by the shared converter helpers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d21f22f58883269444f4654911dac1