### PR TITLE
Fix Kayak CTA discovery and numeric date parsing

### DIFF
--- a/content.js
+++ b/content.js
@@ -14,8 +14,23 @@
   const BTN_GROUP_CLASS = 'kayak-copy-btn-group';
   const OVERLAY_ROOT_ID = 'kayak-copy-overlay-root';
   const MAX_CLIMB   = 12;
-  const SELECT_RX   = /\b(?:Select(?:\s+Flight)?|Choose|View\s+(?:Deal|Flight|Offer)|See\s+(?:Deal|Offer)|Book|Continue(?:\s+to\s+Airline)?|Go\s+to\s+(?:Site|Airline)|Visit\s+(?:Airline|Site)|Check\s+Price|View\s+Offer)\b/i;
-  const CTA_ATTR_HINTS = ['select','book','booking','cta','result-select','provider','price-link','price','offer','deal'];
+  const SELECT_LABEL_PATTERNS = [
+    'Select(?:\\s+(?:Flight|Flights))?',
+    'Choose',
+    'View\\s+(?:Deal|Deals|Flight|Flights|Offer|Offers|Details|Site|Price|Prices|Options)',
+    'See\\s+(?:Deal|Deals|Offer|Offers|Flight|Flights|Details|Options)',
+    'Show\\s+(?:Deal|Deals|Offer|Offers|Flight|Flights|Details|Options)',
+    'Book',
+    'Continue(?:\\s+to\\s+(?:Airline|Site))?',
+    'Go\\s+to\\s+(?:Site|Airline)',
+    'Visit\\s+(?:Airline|Site)',
+    'Check\\s+(?:Price|Prices|Availability)',
+    'See\\s+Availability',
+    'Compare\\s+(?:Fares|Prices|Deals|Offers|Options)',
+    'Get\\s+(?:Deal|Deals|Offer|Offers)'
+  ];
+  const SELECT_RX   = new RegExp(`\\b(?:${SELECT_LABEL_PATTERNS.join('|')})\\b`, 'i');
+  const CTA_ATTR_HINTS = ['select','book','booking','cta','result-select','provider','price-link','price','offer','deal','availability'];
   const CTA_MIN_WIDTH = 90;
   const CTA_MIN_HEIGHT = 32;
   const CTA_MIN_AREA = CTA_MIN_WIDTH * CTA_MIN_HEIGHT;
@@ -2276,7 +2291,8 @@
         'price': 90,
         'provider': 80,
         'offer': 70,
-        'deal': 60
+        'deal': 60,
+        'availability': 75
       };
       let hasPreferredAttr = false;
       for(const hint of CTA_ATTR_HINTS){
@@ -2293,6 +2309,9 @@
       if(/\bcheck\s+price\b/.test(loweredLabel)) score += 24;
       if(/\bdeal\b/.test(loweredLabel)) score += 20;
       if(/\boffer\b/.test(loweredLabel)) score += 20;
+      if(/\bavailability\b/.test(loweredLabel)) score += 24;
+      if(/\bdetails?\b/.test(loweredLabel)) score += 18;
+      if(/\bprices?\b/.test(loweredLabel)) score += 18;
 
       scored.push({ element: candidate, score, order, hasPreferredAttr });
     }

--- a/converter.js
+++ b/converter.js
@@ -28,6 +28,14 @@
     return Object.prototype.hasOwnProperty.call(MONTHS, key) ? key : '';
   }
 
+  function normalizeNumericMonthToken(value){
+    if(!value && value !== 0) return '';
+    const num = parseInt(String(value).trim(), 10);
+    if(!Number.isFinite(num)) return '';
+    if(num < 1 || num > 12) return '';
+    return MONTH_3[num - 1] || '';
+  }
+
   function normalizeDayToken(value){
     if(!value) return '';
     const cleaned = String(value).replace(/(?:st|nd|rd|th)$/i, '');
@@ -41,7 +49,10 @@
     const monIdx = typeof cfg.month === 'number' ? cfg.month : null;
     const dayIdx = typeof cfg.day === 'number' ? cfg.day : null;
     if(monIdx == null || dayIdx == null) return null;
-    const mon = normalizeMonthToken(match[monIdx]);
+    const rawMonth = match[monIdx];
+    const mon = cfg && cfg.monthIsNumeric
+      ? normalizeNumericMonthToken(rawMonth)
+      : normalizeMonthToken(rawMonth);
     const day = normalizeDayToken(match[dayIdx]);
     if(!mon || !day) return null;
     const dowIdx = typeof cfg.dow === 'number' ? cfg.dow : null;
@@ -298,6 +309,27 @@
         day: 1,
         month: 2,
         dow: 3
+      },
+      {
+        regex: new RegExp(`${dowPattern}[,\\s-]+${dayPattern}[\\/\\.\\-]+(\\d{1,2})(?:[\\/\\.\\-]+\\d{2,4})?`, 'i'),
+        dow: 1,
+        day: 2,
+        month: 3,
+        monthIsNumeric: true
+      },
+      {
+        regex: new RegExp(`${dowPattern}[,\\s-]+(\\d{1,2})[\\/\\.\\-]+(\\d{1,2})(?:[\\/\\.\\-]+\\d{2,4})?`, 'i'),
+        dow: 1,
+        day: 2,
+        month: 3,
+        monthIsNumeric: true
+      },
+      {
+        regex: new RegExp(`${dayPattern}[\\/\\.\\-]+(\\d{1,2})(?:[\\/\\.\\-]+\\d{2,4})?(?:[,\\s-]+${dowPattern})?`, 'i'),
+        day: 1,
+        month: 2,
+        dow: 3,
+        monthIsNumeric: true
       }
     ];
 

--- a/converter.test.js
+++ b/converter.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+
+global.window = global;
+require('./airlines.js');
+require('./converter.js');
+
+testNumericDateParsing();
+
+console.log('All converter tests passed.');
+
+function testNumericDateParsing(){
+  const sampleLines = [
+    'Depart Thu 05/10',
+    'United Airlines 123',
+    '7:15 am',
+    '(DUB)',
+    '9:45 am',
+    '(LHR)',
+    'Return Sun 12/10',
+    'United Airlines 456',
+    '11:05 am',
+    '(LHR)',
+    '12:45 pm',
+    '(DUB)'
+  ];
+  const preview = window.peekSegments(sampleLines.join('\n'));
+  assert.ok(preview && Array.isArray(preview.segments), 'Expected segments from peekSegments');
+  assert.strictEqual(preview.segments.length, 2, 'Expected two segments');
+  assert.strictEqual(preview.segments[0].depDate, '05OCT', 'First segment day should be preserved');
+  assert.strictEqual(preview.segments[1].depDate, '12OCT', 'Second segment day should be preserved');
+}


### PR DESCRIPTION
## Summary
- broaden the Kayak CTA text heuristics and attribute hints so overlay pills still appear on kayak.co.uk cards
- accept numeric day/month formats when parsing itinerary headers so copied text from kayak.ie retains the travel day
- add a node-based regression test covering dd/mm headers to guard against future regressions

## Testing
- node rbd.test.js
- node converter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d3f6b068448326947abcca17f1c5b8