### PR TITLE
Fix departure date tracking and dim pills during modals

### DIFF
--- a/content.css
+++ b/content.css
@@ -72,7 +72,7 @@
   box-shadow:0 4px 14px rgba(9,19,33,.25);
   cursor:pointer;
   backdrop-filter:saturate(1.1) blur(3px);
-  transition:transform .18s ease, box-shadow .18s ease, background .22s ease, border-color .22s ease;
+  transition:transform .18s ease, box-shadow .18s ease, background .22s ease, border-color .22s ease, filter .22s ease, opacity .22s ease;
   font:700 14px/1 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;
   color:#101a2a;
   overflow:hidden;
@@ -204,6 +204,21 @@
 
 .kayak-copy-btn--journey.is-copied::after{
   border-radius:999px;
+}
+
+html.kayak-copy-modal-dim .kayak-copy-btn{
+  opacity:.82;
+  filter:saturate(.85) brightness(.84);
+  box-shadow:0 3px 12px rgba(9,19,33,.22);
+}
+
+html.kayak-copy-modal-dim .kayak-copy-btn.kayak-copy-btn--ita{
+  box-shadow:0 3px 12px rgba(0,0,0,.24);
+}
+
+html.kayak-copy-modal-dim .kayak-copy-btn.is-copied{
+  filter:saturate(.9) brightness(.88);
+  box-shadow:0 4px 14px rgba(12,94,40,.32);
 }
 
 .kayak-copy-cabin-hint{

--- a/converter.js
+++ b/converter.js
@@ -608,7 +608,10 @@
     }
 
     const applyDepartsOverride = (line) => {
-      const depInfo = parseDepartsDate(line || '');
+      if(!line) return false;
+      const raw = String(line);
+      if(/\bArriv/i.test(raw)) return false;
+      const depInfo = parseDepartsDate(raw);
       if(depInfo){
         const nextDow = depInfo.dow || (currentDate ? currentDate.dow : '');
         currentDate = { day: depInfo.day, mon: depInfo.mon, dow: nextDow };

--- a/converter.test.js
+++ b/converter.test.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+
+global.window = global;
+require('./airlines.js');
+require('./converter.js');
+
+const sampleItinerary = [
+  'Depart • Sun, Apr 12',
+  'Flight 1 • Sun, Apr 12',
+  'Iberia 4067 · Operated by American Airlines',
+  '11:51 am',
+  'Seattle (SEA)',
+  '5:55 pm',
+  'Chicago (ORD)',
+  'Change planes in Chicago (ORD)',
+  'Iberia 4382 · Operated by American Airlines',
+  '6:55 pm',
+  'Chicago (ORD)',
+  '10:30 am',
+  'Barcelona (BCN)',
+  'Arrives Mon, Apr 13',
+  'Return • Mon, Apr 27',
+  'Flight 2 • Mon, Apr 27',
+  'Iberia 1756',
+  '1:15 pm',
+  'Seville (SVQ)',
+  '2:25 pm',
+  'Madrid (MAD)',
+  'Iberia 8049',
+  '4:40 pm',
+  'Madrid (MAD)',
+  '6:50 pm',
+  'Chicago (ORD)',
+  'Iberia 4951',
+  '8:25 pm',
+  'Chicago (ORD)',
+  '11:05 pm',
+  'Seattle (SEA)'
+].join('\n');
+
+const peek = window.peekSegments(sampleItinerary);
+assert.ok(peek && Array.isArray(peek.segments), 'peekSegments should return segments');
+assert.strictEqual(peek.segments.length, 5, 'expected five segments in sample');
+assert.strictEqual(peek.segments[1].depDate, '12APR', 'second leg should retain original departure date');
+assert.strictEqual(peek.segments[1].arrDate, '13APR M', 'second leg should carry forward arrival date context');
+
+const lines = window.convertTextToI(sampleItinerary).split('\n');
+assert.ok(lines[1].includes('12APR'), 'second line should show original departure date');
+assert.ok(lines[1].includes('13APR M'), 'second line should include arrival date suffix');
+
+console.log('✓ converter maintains departure date continuity for connecting segments');


### PR DESCRIPTION
## Summary
- prevent arrival metadata from advancing the working departure date when parsing connecting segments
- add a regression test covering the SEA-ORD-BCN itinerary to ensure departure and arrival dates are preserved correctly
- detect Kayak modal dialogs and gently dim injected pills so they blend when the host page greys out

## Testing
- node converter.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d43e4729f08326bf8cbaa5a36a2a39