### PR TITLE
Add leading seat count indicator to availability commands

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1557,7 +1557,7 @@
     }
     const dayPart = String(dayNumeric);
 
-    let command = `${dayPart}${month}${origin}${destination}`;
+    let command = `1${dayPart}${month}${origin}${destination}`;
 
     const connectionList = Array.isArray(direction.connections)
       ? direction.connections.filter(Boolean)

--- a/converter.test.js
+++ b/converter.test.js
@@ -148,9 +148,9 @@ assert.ok(/01MAR/.test(overnightLines[0]), 'first segment should retain original
 assert.ok(/02MAR/.test(overnightLines[1]), 'time wrap should advance to next calendar day for continuing leg');
 
 const outboundAvailability = window.convertTextToAvailability(sampleItinerary, { direction: 'outbound' });
-assert.strictEqual(outboundAvailability, '12APRSEABCN12AORD/MAD¥IB', 'outbound availability should collapse to SEA-BCN with connections');
+assert.strictEqual(outboundAvailability, '112APRSEABCN12AORD/MAD¥IB', 'outbound availability should collapse to SEA-BCN with connections');
 
 const inboundAvailability = window.convertTextToAvailability(sampleItinerary, { direction: 'inbound' });
-assert.strictEqual(inboundAvailability, '27APRSVQSEA12AMAD/DFW¥IB', 'inbound availability should collapse to SVQ-SEA with connections');
+assert.strictEqual(inboundAvailability, '127APRSVQSEA12AMAD/DFW¥IB', 'inbound availability should collapse to SVQ-SEA with connections');
 
 console.log('✓ converter maintains departure date continuity for connecting segments');


### PR DESCRIPTION
## Summary
- prefix availability commands with the seat-count indicator so copied text starts with `1`
- update unit tests to match the new command format

## Testing
- node converter.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d567c8d3708326a1f8452b147242ab