### PR TITLE
Adjust availability pill layout

### DIFF
--- a/content.css
+++ b/content.css
@@ -78,6 +78,15 @@
   overflow:hidden;
 }
 
+.kayak-copy-btn.kayak-copy-btn--availability{
+  width:auto;
+  min-width:72px;
+  height:44px;
+  padding:0 16px;
+  border-radius:999px;
+  max-width:min(360px, 72vw);
+}
+
 .kayak-copy-btn.kayak-copy-btn--ita{
   width:36px;
   height:36px;
@@ -145,6 +154,17 @@
   letter-spacing:.04em;
   transition:opacity .18s ease, transform .18s ease;
 }
+.kayak-copy-btn.kayak-copy-btn--availability .pill-text{
+  position:relative;
+  inset:auto;
+  width:auto;
+  height:auto;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:0 4px;
+  white-space:nowrap;
+}
 .kayak-copy-btn .pill-text{ color:inherit; }
 .kayak-copy-btn .pill-check{
   font-size:20px;
@@ -169,6 +189,10 @@
   border:2px solid rgba(45,211,111,.45);
   pointer-events:none;
   animation:kayak-copy-ping .45s ease-out forwards;
+}
+
+.kayak-copy-btn.kayak-copy-btn--availability.is-copied::after{
+  border-radius:999px;
 }
 
 .kayak-copy-btn.kayak-copy-btn--journey{

--- a/content.js
+++ b/content.js
@@ -1076,7 +1076,11 @@
     if (IS_ITA){
       btn.classList.add('kayak-copy-btn--ita');
     }
-    if(config && config.variant === 'journey'){
+    const isJourneyVariant = !!(config && config.variant === 'journey');
+    if(!IS_ITA && config && config.copyKind === 'availability' && !isJourneyVariant){
+      btn.classList.add('kayak-copy-btn--availability');
+    }
+    if(isJourneyVariant){
       btn.classList.add('kayak-copy-btn--journey');
     }
     btn.type = 'button';


### PR DESCRIPTION
## Summary
- add a dedicated class to availability copy buttons so they can be styled separately
- widen availability pills and keep their text on one line while preserving copied animation styling

## Testing
- node converter.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d58426067c8326bee880a914dafb59