### PR TITLE
Refresh popup layout and availability previews

### DIFF
--- a/content.css
+++ b/content.css
@@ -174,10 +174,10 @@
 }
 
 .kayak-copy-btn.is-copied{
-  background:linear-gradient(180deg, #2dd36f 0%, #1ea85a 100%);
-  border-color:rgba(255,255,255,.92);
+  background:linear-gradient(180deg, #5a77ff 0%, #1e40ff 100%);
+  border-color:rgba(231, 237, 255, .95);
   color:#fff;
-  box-shadow:0 6px 18px rgba(12,94,40,.38);
+  box-shadow:0 6px 18px rgba(38, 64, 178, .36);
 }
 .kayak-copy-btn.is-copied .pill-text{ opacity:0; transform:scale(.7); }
 .kayak-copy-btn.is-copied .pill-check{ opacity:1; transform:scale(1); color:#fff; }
@@ -186,7 +186,7 @@
   position:absolute;
   inset:-4px;
   border-radius:50%;
-  border:2px solid rgba(45,211,111,.45);
+  border:2px solid rgba(90, 119, 255, .45);
   pointer-events:none;
   animation:kayak-copy-ping .45s ease-out forwards;
 }
@@ -239,8 +239,8 @@ html.kayak-copy-modal-dim .kayak-copy-btn.kayak-copy-btn--ita{
 }
 
 html.kayak-copy-modal-dim .kayak-copy-btn.is-copied{
-  filter:saturate(.9) brightness(.88);
-  box-shadow:0 4px 14px rgba(12,94,40,.32);
+  filter:saturate(.94) brightness(.9);
+  box-shadow:0 4px 14px rgba(38,64,178,.32);
 }
 
 .kayak-copy-cabin-hint{

--- a/popup.html
+++ b/popup.html
@@ -33,26 +33,26 @@
       font: 14px/1.55 "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
       background: radial-gradient(circle at top left, rgba(75, 107, 255, 0.12), transparent 46%), var(--color-bg);
       color: var(--color-text);
-      min-width: 360px;
-      padding: 24px;
+      min-width: 320px;
+      padding: 20px;
       display: flex;
       justify-content: center;
     }
 
     .popup {
-      width: min(420px, 92vw);
+      width: min(360px, 94vw);
       display: grid;
-      gap: 20px;
+      gap: 18px;
     }
 
     .card {
       background: var(--color-surface);
       border-radius: var(--radius-md);
-      padding: 20px;
+      padding: 18px;
       border: 1px solid var(--color-border);
       box-shadow: var(--shadow-sm);
       display: grid;
-      gap: 18px;
+      gap: 16px;
     }
 
     .card__header {
@@ -236,38 +236,43 @@
       border: none;
       border-radius: 999px;
       font-weight: 600;
-      padding: 0.6rem 1.2rem;
-      font-size: 0.9rem;
+      padding: 0.58rem 1.15rem;
+      font-size: 0.88rem;
       cursor: pointer;
-      transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition);
+      transition: transform var(--transition), box-shadow var(--transition), background var(--transition), color var(--transition), border-color var(--transition);
+      background: #fff;
+      color: var(--color-accent-strong);
+      border: 1px solid rgba(75, 107, 255, 0.35);
+      box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
     }
 
     .btn-primary {
-      background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
-      color: #fff;
-      box-shadow: var(--shadow-sm);
+      border-color: rgba(75, 107, 255, 0.45);
+      box-shadow: 0 6px 16px rgba(15, 23, 42, 0.14);
     }
 
     .btn-primary:hover,
     .btn-primary:focus {
       transform: translateY(-1px);
-      box-shadow: var(--shadow-md);
+      box-shadow: 0 10px 24px rgba(15, 23, 42, 0.18);
       outline: none;
     }
 
     .btn-secondary {
-      background: rgba(75, 107, 255, 0.12);
-      color: var(--color-accent-strong);
+      color: var(--color-accent);
+      border-color: rgba(75, 107, 255, 0.28);
+      box-shadow: 0 3px 8px rgba(15, 23, 42, 0.08);
     }
 
     .btn-secondary:hover,
     .btn-secondary:focus {
-      background: rgba(75, 107, 255, 0.2);
+      background: rgba(75, 107, 255, 0.08);
+      border-color: rgba(75, 107, 255, 0.42);
       outline: none;
     }
 
     .btn:disabled {
-      opacity: 0.6;
+      opacity: 0.55;
       cursor: default;
       transform: none;
       box-shadow: none;
@@ -291,10 +296,11 @@
       display: none;
       padding: 0.25rem 0.7rem;
       border-radius: 999px;
-      background: rgba(45, 180, 124, 0.12);
-      color: var(--color-success);
+      background: linear-gradient(135deg, rgba(75, 107, 255, 0.85), rgba(30, 64, 255, 0.95));
+      color: #fff;
       font-size: 0.75rem;
       font-weight: 600;
+      box-shadow: 0 6px 18px rgba(15, 23, 42, 0.18);
     }
 
     .converter-actions {
@@ -352,21 +358,24 @@
     }
 
     .availability-preview__copy {
-      border: none;
-      border-radius: 999px;
-      padding: 0.45rem 0.8rem;
+      padding: 0.42rem 0.78rem;
       font-size: 0.75rem;
       font-weight: 600;
-      background: linear-gradient(135deg, var(--color-accent), var(--color-accent-strong));
-      color: #fff;
+      background: #fff;
+      color: var(--color-accent-strong);
       cursor: pointer;
-      transition: transform var(--transition), box-shadow var(--transition);
+      border: 1px solid rgba(75, 107, 255, 0.35);
+      border-radius: 999px;
+      box-shadow: 0 3px 9px rgba(15, 23, 42, 0.08);
+      transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
     }
 
     .availability-preview__copy:hover,
     .availability-preview__copy:focus {
       transform: translateY(-1px);
-      box-shadow: var(--shadow-sm);
+      box-shadow: 0 6px 16px rgba(15, 23, 42, 0.16);
+      border-color: rgba(75, 107, 255, 0.5);
+      background: rgba(75, 107, 255, 0.06);
       outline: none;
     }
 


### PR DESCRIPTION
## Summary
- shrink the popup canvas and restyle buttons and status indicators to a white-and-blue theme
- flash the Copy button label after conversions and surface OB/IB or multi-city availability commands in the preview
- align the on-page copy pill checkmark animation with the blue theme

## Testing
- `npx web-ext lint`


------
https://chatgpt.com/codex/tasks/task_e_68d6f137fe848326aa8ac840249ac7fe