### PR TITLE
Improve TAP RBD handling and VI* cabin detection

### DIFF
--- a/rbd.js
+++ b/rbd.js
@@ -27,7 +27,7 @@
     LO: { BUSINESS: ['Z', 'D', 'C'], PREMIUM: ['P', 'A', 'R'], ECONOMY: ['Y', 'B', 'M', 'H', 'K', 'Q', 'T', 'V', 'L', 'S', 'O', 'U'] },
     IB: { BUSINESS: ['J', 'C', 'D', 'I'], PREMIUM: ['W', 'P'], ECONOMY: ['Y', 'B', 'H', 'K', 'M', 'L', 'V', 'S', 'N', 'O', 'Q'] },
     OS: { BUSINESS: ['J', 'C', 'D', 'Z'], PREMIUM: ['G', 'E', 'N'], ECONOMY: ['Y', 'B', 'M', 'H', 'Q', 'V', 'W', 'S', 'T', 'L', 'K', 'E'] },
-    TP: { BUSINESS: ['J', 'C', 'D', 'Z'], ECONOMY: ['Y', 'B', 'M', 'H', 'Q', 'V', 'S', 'K', 'L', 'O', 'G', 'W', 'U'] },
+    TP: { BUSINESS: ['C', 'D', 'Z', 'J', 'R'], ECONOMY: ['Y', 'B', 'M', 'H', 'Q', 'V', 'S', 'K', 'L', 'O', 'G', 'W', 'U'] },
 
     // Middle East / Asia-Pacific (selection)
     QR: { FIRST: ['P', 'F', 'A'], BUSINESS: ['J', 'C', 'D', 'I', 'R'], ECONOMY: ['Y', 'B', 'H', 'K', 'M', 'L', 'V', 'S', 'N', 'Q', 'T', 'O'] },

--- a/rbd.test.js
+++ b/rbd.test.js
@@ -19,6 +19,10 @@ test('AA + BUSINESS → J', () => {
   assert.strictEqual(getPreferredRBD('AA', 'BUSINESS'), 'J');
 });
 
+test('TP + BUSINESS → C', () => {
+  assert.strictEqual(getPreferredRBD('TP', 'BUSINESS'), 'C');
+});
+
 test('DL + PREMIUM → P', () => {
   assert.strictEqual(getPreferredRBD('DL', 'PREMIUM'), 'P');
 });


### PR DESCRIPTION
## Summary
- reorder TAP Air Portugal business booking codes to prefer the highest fare bucket
- enhance the VI* to *I converter to read cabin metadata, apply short-haul first-class logic, and choose airline-preferred RBDs
- capture cabin and elapsed-time details when parsing VI* segments so per-segment booking classes can be emitted

## Testing
- node rbd.test.js
- node converter.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d72a5b6d648326b25354748c56ed7e