### PR TITLE
Ensure VI converter honors airline RBDs for cabin detection

### DIFF
--- a/popup.convert.test.js
+++ b/popup.convert.test.js
@@ -1,0 +1,93 @@
+const assert = require('assert');
+
+global.window = global;
+
+const stubElement = () => ({
+  style: {},
+  value: '',
+  textContent: '',
+  innerHTML: '',
+  disabled: false,
+  checked: false,
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  setAttribute: () => {},
+  getAttribute: () => '',
+  focus: () => {},
+  blur: () => {},
+  select: () => {},
+  appendChild: () => {},
+  querySelector: () => null,
+  querySelectorAll: () => [],
+  classList: {
+    add: () => {},
+    remove: () => {},
+    toggle: () => {},
+    contains: () => false
+  }
+});
+
+const elements = new Map();
+
+global.document = {
+  getElementById(id){
+    if (!elements.has(id)){
+      elements.set(id, stubElement());
+    }
+    return elements.get(id);
+  },
+  createElement: () => stubElement(),
+  createRange: () => ({
+    selectNodeContents: () => {},
+    setStart: () => {},
+    setEnd: () => {}
+  }),
+  queryCommandSupported: () => false,
+  execCommand: () => false,
+  body: {
+    appendChild: () => {},
+    removeChild: () => {}
+  }
+};
+
+global.window.getSelection = () => ({
+  removeAllRanges: () => {},
+  addRange: () => {}
+});
+
+global.navigator = {
+  clipboard: {
+    writeText: async () => {}
+  }
+};
+
+global.chrome = {
+  storage: {
+    sync: {
+      get: (_, cb) => cb({}),
+      set: (_, cb) => cb && cb(),
+    },
+    onChanged: {
+      addListener: () => {}
+    }
+  }
+};
+
+require('./airlines.js');
+require('./rbd.js');
+
+const { convertViToI } = require('./popup.js');
+
+const sampleText = `FLIGHT  DATE  SEGMENT DPTR  ARVL    MLS  EQP  ELPD MILES SM\n 1 AA  293 22OCT DEL JFK 1130P  605A¥1 LS   789 16.05  7318  N\nDEP-TERMINAL 3                 ARR-TERMINAL 8                 \nONEWORLD\nCABIN-PREMIUM ECONOMY\n 2 AA 2813 23OCT JFK AUS 1132A  237P   F    738  4.05  1521  N\nDEP-TERMINAL 8                 \nONEWORLD\nCABIN-ECONOMY`;
+
+const result = convertViToI(sampleText, { autoCabin: true, bookingClass: 'J', segmentStatus: 'SS1' });
+
+assert.ok(result && typeof result.text === 'string', 'convertViToI should return text output');
+
+const firstLine = result.text.split('\n')[0] || '';
+assert.ok(/AA\s?293W/.test(firstLine), 'AA premium economy segment should use W booking class');
+
+assert.ok(Array.isArray(result.segments), 'segments should be returned');
+assert.strictEqual(result.segments[0].bookingClass, 'W', 'first segment booking class should be W');
+
+console.log('All tests passed.');

--- a/popup.html
+++ b/popup.html
@@ -517,6 +517,7 @@
     </section>
   </main>
   <script src="airlines.js"></script>
+  <script src="rbd.js"></script>
   <script src="converter.js"></script>
   <script src="popup.js"></script>
 </body>

--- a/popup.js
+++ b/popup.js
@@ -1298,4 +1298,13 @@
     const base = num.length < 4 ? `${airlineCode} ${num}` : `${airlineCode}${num}`;
     return `${base}${bookingClass}`;
   }
+
+  if (typeof module !== 'undefined' && module.exports){
+    module.exports = {
+      convertViToI,
+      pickPreferredBookingClass,
+      resolveCabinForSegment,
+      normalizeCabinValue
+    };
+  }
 })();


### PR DESCRIPTION
## Summary
- load the airline RBD map in the popup so VI auto-cabin detection can pick carrier-specific booking classes
- export the popup conversion helpers for tests and add a regression test covering AA premium economy VI* parsing

## Testing
- node rbd.test.js
- node popup.convert.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d96a5527c88326a84ab2076b07aecc