### PR TITLE
Ensure Air Serbia itineraries include every segment

### DIFF
--- a/content.js
+++ b/content.js
@@ -3484,6 +3484,31 @@
     while (walker.nextNode()) tokens.push(walker.currentNode.nodeValue.replace(/\s+/g,' ').trim());
 
     const keep = [];
+    const resolveAirlineNameToken = (raw) => {
+      const cleaned = (raw || '')
+        .replace(/[•·]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+      if(!cleaned) return null;
+      const tryLookup = (name) => {
+        if(!name) return false;
+        if(typeof lookupAirlineCodeByName === 'function'){
+          try {
+            if(lookupAirlineCodeByName(name)) return true;
+          } catch (err) {
+            return false;
+          }
+        } else if(typeof AIRLINE_CODES !== 'undefined'){
+          const key = name.toUpperCase();
+          if(Object.prototype.hasOwnProperty.call(AIRLINE_CODES, key)) return true;
+        }
+        return false;
+      };
+      if(tryLookup(cleaned)) return cleaned;
+      const stripped = cleaned.replace(/\s+\d{1,4}\b.*$/, '').trim();
+      if(stripped && tryLookup(stripped)) return stripped;
+      return null;
+    };
     const airlineLike   = /(Airlines?|Airways|Aviation|Virgin Atlantic|British Airways|United|Delta|KLM|Air Canada|American|Lufthansa|SWISS|Austrian|TAP|Aer Lingus|Iberia|Finnair|SAS|Turkish|Emirates|Qatar|Etihad|JetBlue|Alaska|Hawaiian|Frontier|Spirit|Condor|Icelandair|Air Transat|Porter|Sun Country|Eurowings|TUI Fly)/i;
     const aircraftLike  = /(Boeing|Airbus|Embraer|Bombardier|CRJ|E-?Jet|Dreamliner|neo|MAX|777|787|737|A3\d{2}|A220|A321|A320|A319|A330|A350)/i;
     const timeLike      = /^(?:[01]?\d|2[0-3]):[0-5]\d(?:\s?(?:am|pm))?$/i;
@@ -3517,6 +3542,11 @@
         if(bookingClassLike.test(t)){
           keep.push(t);
         }
+        continue;
+      }
+
+      if (resolveAirlineNameToken(t)){
+        keep.push(t);
         continue;
       }
 

--- a/converter.test.js
+++ b/converter.test.js
@@ -459,4 +459,58 @@ const multiCarrierItinerary = [
 const multiCarrierAvailability = window.convertTextToAvailability(multiCarrierItinerary, { direction: 'outbound' });
 assert.strictEqual(multiCarrierAvailability, '112JUNIADNBO12ACPH/AMS¥SK¥KQ¥KQ', 'availability should list each marketing carrier sequentially');
 
+const airSerbiaSample = [
+  'Depart • Thu, Jan 22',
+  '11h 45m',
+  '*I✓',
+  '',
+  'ZRH-BEG',
+  '✓',
+  'Air Serbia',
+  'Air Serbia 501',
+  'Airbus A330-200',
+  '3:00 pm',
+  'New York John F Kennedy Intl (JFK)',
+  '8h 40m',
+  'Overnight flight',
+  '5:40 am',
+  'Belgrade Nikola Tesla (BEG)',
+  'Arrives Fri, Jan 23',
+  '1h 15m•Change planes in Belgrade (BEG)',
+  'Air Serbia',
+  'Air Serbia 330',
+  'Airbus A319',
+  '6:55 am',
+  'Belgrade Nikola Tesla (BEG)',
+  '1h 50m',
+  '8:45 am',
+  'Zurich (ZRH)',
+  'Return • Sun, Feb 1',
+  '13h 50m',
+  'Air Serbia',
+  'Air Serbia 331 · Operated by Bulgaria Air For Air Serbia',
+  'Embraer 190',
+  '9:30 am',
+  'Zurich (ZRH)',
+  '1h 40m',
+  '11:10 am',
+  'Belgrade Nikola Tesla (BEG)',
+  '2h 00m•Change planes in Belgrade (BEG)',
+  'Air Serbia',
+  'Air Serbia 500',
+  'Airbus A330-200',
+  '1:10 pm',
+  'Belgrade Nikola Tesla (BEG)',
+  '10h 10m',
+  '5:20 pm',
+  'New York John F Kennedy Intl (JFK)'
+].join('\n');
+
+const airSerbiaPeek = window.peekSegments(airSerbiaSample);
+assert.strictEqual(airSerbiaPeek.segments.length, 4, 'Air Serbia itinerary should produce four segments');
+assert.deepStrictEqual(airSerbiaPeek.segments.map(seg => seg.airlineCode), ['JU','JU','JU','JU'], 'each Air Serbia segment should retain JU designator');
+
+const airSerbiaLines = window.convertTextToI(airSerbiaSample).split('\n').filter(Boolean);
+assert.ok(airSerbiaLines.some(line => /JU\s?501J/.test(line)), 'converted output should include the JFK-BEG segment');
+
 console.log('✓ converter maintains departure date continuity for connecting segments');


### PR DESCRIPTION
## Summary
- allow the Kayak text extractor to keep tokens that resolve to a known airline name, even when the line does not explicitly say "Airlines"
- add a regression test covering the sample Air Serbia itinerary to ensure four segments are emitted

## Testing
- node converter.test.js *(fails: existing overnight wrap assertion still expects next-day rollover)*
- node popup.convert.test.js


------
https://chatgpt.com/codex/tasks/task_e_68e2a71a15948326920c974a7293c987