### PR TITLE
Handle Saudia listings with appended carrier codes

### DIFF
--- a/airlines.js
+++ b/airlines.js
@@ -448,13 +448,33 @@ Object.keys(AIRLINE_CODES).forEach((key) => {
 
 function lookupAirlineCodeByName(name){
     if(!name && name !== 0) return null;
-    const directKey = String(name).trim().toUpperCase();
+    const raw = String(name);
+    const directKey = raw.trim().toUpperCase();
     if(directKey && Object.prototype.hasOwnProperty.call(AIRLINE_CODES, directKey)){
         return AIRLINE_CODES[directKey];
     }
-    const normalized = normalizeAirlineNameKey(name);
+    const normalized = normalizeAirlineNameKey(raw);
     if(normalized && Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, normalized)){
         return AIRLINE_NORMALIZED_CODES[normalized];
+    }
+    if(normalized){
+        let trimmed = normalized;
+        while(true){
+            const next = trimmed.replace(/\s+[A-Z0-9]{2,3}$/, '');
+            if(next === trimmed) break;
+            trimmed = next;
+            if(trimmed && Object.prototype.hasOwnProperty.call(AIRLINE_NORMALIZED_CODES, trimmed)){
+                return AIRLINE_NORMALIZED_CODES[trimmed];
+            }
+        }
+        const suffixMatch = normalized.match(/\s([A-Z0-9]{2})$/);
+        if(suffixMatch){
+            return suffixMatch[1];
+        }
+    }
+    const parenSuffix = raw.match(/\(([A-Z0-9]{2})\)\s*$/);
+    if(parenSuffix){
+        return parenSuffix[1].toUpperCase();
     }
     return null;
 }

--- a/converter.js
+++ b/converter.js
@@ -441,7 +441,7 @@
       .trim();
     if(!cleaned) return null;
     if(isLikelyEquipmentLine(cleaned)) return null;
-    const m = cleaned.match(/^([A-Za-z][A-Za-z\s'&.-]*?)\s+(\d{1,4})\b/);
+    const m = cleaned.match(/^([A-Za-z][A-Za-z\s'&.()/-]*?)\s+(\d{1,4})\b/);
     if(!m) return null;
     const airlineName = m[1].trim();
     if(/\bOPERATED BY\b/i.test(airlineName)) return null;

--- a/converter.test.js
+++ b/converter.test.js
@@ -4,6 +4,48 @@ global.window = global;
 require('./airlines.js');
 require('./converter.js');
 
+assert.strictEqual(
+  window.lookupAirlineCodeByName('Saudia (SV)'),
+  'SV',
+  'Saudia alias with trailing code should resolve to SV'
+);
+assert.strictEqual(
+  window.lookupAirlineCodeByName('Saudia (SV) 20'),
+  'SV',
+  'Saudia line with flight number should resolve to SV'
+);
+
+const saudiaSample = [
+  'Depart • Wed, Nov 19',
+  'Flight 1 • Wed, Nov 19',
+  '11h 30m',
+  'Saudia',
+  'Saudia (SV) 20',
+  'Boeing 777-300',
+  '11:00 am',
+  'New York John F Kennedy Intl (JFK)',
+  'Overnight flight',
+  '6:30 am',
+  'Jeddah King Abdulaziz Intl (JED)',
+  'Arrives Thu, Nov 20',
+  'Return • Wed, Apr 8',
+  'Flight 2 • Wed, Apr 8',
+  '12h 55m',
+  'Saudia',
+  'Saudia (SV) 21',
+  'Boeing 777-300',
+  '3:05 am',
+  'Jeddah King Abdulaziz Intl (JED)',
+  '9:50 am',
+  'New York John F Kennedy Intl (JFK)',
+  'Arrives Wed, Apr 8'
+].join('\n');
+
+const saudiaLines = window.convertTextToI(saudiaSample).split('\n');
+assert.strictEqual(saudiaLines.length, 2, 'Saudia sample should produce two segments');
+assert.ok(/SV\s+20/.test(saudiaLines[0]), 'Outbound Saudia segment should use SV 20');
+assert.ok(/SV\s+21/.test(saudiaLines[1]), 'Inbound Saudia segment should use SV 21');
+
 const sampleItinerary = [
   'Depart • Sun, Apr 12',
   'Flight 1 • Sun, Apr 12',


### PR DESCRIPTION
## Summary
- normalize airline lookups to strip trailing carrier designators such as "(SV)"
- allow flight number parsing to accept airline names containing parentheses
- add a Saudia regression test that covers the new format and lookup behavior

## Testing
- node converter.test.js
- node popup.convert.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e53ab1de208326a7072e813b4263cf