### PR TITLE
Add interactive layout sandbox with zoomable grid

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -86,6 +86,136 @@
       gap: 14px;
     }
 
+    .card--layout {
+      gap: 18px;
+    }
+
+    .layout-board {
+      position: relative;
+      border-radius: calc(var(--radius-md) - 2px);
+      border: 1px solid rgba(75, 107, 255, 0.14);
+      background: radial-gradient(circle at top right, rgba(75, 107, 255, 0.12), transparent 60%),
+        radial-gradient(circle at bottom left, rgba(75, 107, 255, 0.08), transparent 62%),
+        rgba(244, 246, 255, 0.9);
+      min-height: 260px;
+      overflow: hidden;
+      cursor: grab;
+      touch-action: none;
+      user-select: none;
+      transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+    }
+
+    .layout-board--panning {
+      cursor: grabbing;
+    }
+
+    .layout-board canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      display: block;
+      pointer-events: none;
+    }
+
+    .layout-board__card {
+      position: absolute;
+      top: 0;
+      left: 0;
+      transform-origin: top left;
+      width: 280px;
+      height: 190px;
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 18px 22px;
+      border-radius: 22px;
+      background: rgba(255, 255, 255, 0.94);
+      box-shadow: 0 20px 44px rgba(15, 23, 42, 0.18);
+      backdrop-filter: saturate(1.08) blur(10px);
+      border: 1px solid rgba(75, 107, 255, 0.18);
+    }
+
+    .layout-board__card--resizing {
+      box-shadow: 0 24px 54px rgba(30, 64, 255, 0.3);
+      border-color: rgba(75, 107, 255, 0.32);
+    }
+
+    .layout-board__pill {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 52px;
+      height: 52px;
+      border-radius: 50%;
+      background: linear-gradient(180deg, rgba(248, 249, 255, 1) 0%, rgba(232, 236, 255, 1) 100%);
+      border: 2px solid rgba(64, 86, 217, 0.78);
+      color: #3146c9;
+      font-weight: 700;
+      font-size: 1.05rem;
+      box-shadow: 0 8px 22px rgba(15, 23, 42, 0.16);
+    }
+
+    .layout-board__meta {
+      display: grid;
+      gap: 4px;
+    }
+
+    .layout-board__meta strong {
+      font-size: 0.92rem;
+      color: var(--color-text);
+    }
+
+    .layout-board__meta small {
+      font-size: 0.74rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(91, 96, 114, 0.7);
+    }
+
+    .layout-board__handle {
+      position: absolute;
+      right: -18px;
+      bottom: -18px;
+      width: 54px;
+      height: 54px;
+      border-radius: 50%;
+      border: none;
+      padding: 0;
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.92) 0%, rgba(75, 107, 255, 0.92) 86%, rgba(30, 64, 255, 0.95) 100%);
+      box-shadow: 0 12px 24px rgba(30, 64, 255, 0.32);
+      border: 3px solid rgba(255, 255, 255, 0.85);
+      cursor: nwse-resize;
+      transition: transform var(--transition), box-shadow var(--transition), filter var(--transition);
+    }
+
+    .layout-board__handle::after {
+      content: '';
+      position: absolute;
+      inset: 14px;
+      border-radius: 50%;
+      background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.95) 0%, rgba(133, 152, 255, 0.95) 100%);
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+    }
+
+    .layout-board__handle:focus-visible {
+      outline: none;
+      box-shadow: 0 0 0 4px rgba(75, 107, 255, 0.3);
+    }
+
+    .layout-board__handle:hover,
+    .layout-board__handle:active {
+      transform: translate(1px, 1px) scale(1.04);
+      box-shadow: 0 16px 30px rgba(30, 64, 255, 0.36);
+      filter: brightness(1.03);
+    }
+
+    .layout-board__card-body {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+    }
+
     .card__header {
       display: grid;
       gap: 5px;
@@ -449,6 +579,10 @@
       .toggle-help {
         margin-left: 0;
       }
+
+      .layout-board {
+        min-height: 220px;
+      }
     }
   </style>
 </head>
@@ -517,6 +651,37 @@
       <div class="field">
         <label class="field__label" for="iOutput">*I result</label>
         <textarea id="iOutput" class="field__control field__control--textarea" readonly placeholder="Converted *I output will appear here"></textarea>
+      </div>
+    </section>
+
+    <section class="card card--layout">
+      <header class="card__header">
+        <span class="card__eyebrow">Canvas</span>
+        <h2 class="card__title">Layout sandbox</h2>
+        <p class="card__subtitle">Drag to pan, scroll to zoom, and resize the preview card with the glowing corner handle.</p>
+      </header>
+      <div id="layoutBoard" class="layout-board" role="application" aria-label="Layout sandbox canvas">
+        <canvas id="layoutCanvas" aria-hidden="true"></canvas>
+        <div
+          id="layoutCard"
+          class="layout-board__card"
+          role="group"
+          aria-label="Resizable card preview"
+        >
+          <div class="layout-board__card-body">
+            <span class="layout-board__pill" aria-hidden="true">*I</span>
+            <div class="layout-board__meta">
+              <strong>Clipboard ready</strong>
+              <small>Visual grid preview</small>
+            </div>
+          </div>
+          <button
+            id="layoutCardHandle"
+            type="button"
+            class="layout-board__handle"
+            aria-label="Resize preview card"
+          ></button>
+        </div>
       </div>
     </section>
   </main>

--- a/popup.js
+++ b/popup.js
@@ -27,6 +27,10 @@
   const bookingStatusNote = document.getElementById('bookingStatusNote');
   const restoreAutoBtn = document.getElementById('restoreAutoBtn');
   const availabilityPreview = document.getElementById('availabilityPreview');
+  const layoutBoard = document.getElementById('layoutBoard');
+  const layoutCanvas = document.getElementById('layoutCanvas');
+  const layoutCard = document.getElementById('layoutCard');
+  const layoutHandle = document.getElementById('layoutCardHandle');
 
   const COPY_SUCCESS_LABEL = 'Copied';
   const COPY_RESET_DELAY = 1600;
@@ -41,6 +45,16 @@
   if (availabilityPreview){
     availabilityPreview.style.display = 'none';
     availabilityPreview.setAttribute('aria-hidden', 'true');
+  }
+
+  if (
+    layoutBoard &&
+    layoutCanvas &&
+    layoutCard &&
+    layoutHandle &&
+    typeof layoutCanvas.getContext === 'function'
+  ){
+    initLayoutBoardPreview(layoutBoard, layoutCanvas, layoutCard, layoutHandle);
   }
 
   const state = {
@@ -475,6 +489,366 @@
     }
     document.body.removeChild(temp);
     return ok;
+  }
+
+  function initLayoutBoardPreview(boardEl, canvasEl, cardEl, handleEl){
+    const ctx = canvasEl.getContext('2d');
+    if (!ctx){
+      return;
+    }
+
+    const boardState = {
+      boardEl,
+      canvasEl,
+      cardEl,
+      handleEl,
+      ctx,
+      scale: 1,
+      minScale: 0.55,
+      maxScale: 2.75,
+      panX: 0,
+      panY: 0,
+      panMultiplier: 1.35,
+      gridSpacing: 68,
+      majorStep: 4,
+      gridExtent: 20000,
+      viewportWidth: 0,
+      viewportHeight: 0,
+      dpr: typeof window !== 'undefined' && window.devicePixelRatio ? window.devicePixelRatio : 1,
+      pointerId: null,
+      isPanning: false,
+      lastPointerX: 0,
+      lastPointerY: 0,
+      resizePointerId: null,
+      isResizing: false,
+      resizeStart: null,
+      rafHandle: null,
+      raf:
+        typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+          ? window.requestAnimationFrame.bind(window)
+          : (cb) => setTimeout(cb, 16),
+      card: {
+        width: 280,
+        height: 190,
+        minWidth: 180,
+        minHeight: 140,
+        maxWidth: 520,
+        maxHeight: 420,
+        x: 0,
+        y: 0
+      }
+    };
+
+    boardState.card.x = -boardState.card.width / 2;
+    boardState.card.y = -boardState.card.height / 2;
+
+    const scheduleDraw = () => {
+      if (boardState.rafHandle != null){
+        return;
+      }
+      boardState.rafHandle = boardState.raf(() => {
+        boardState.rafHandle = null;
+        drawBoard();
+      });
+    };
+
+    const updateCanvasSize = () => {
+      const width = boardEl.clientWidth;
+      const height = boardEl.clientHeight;
+      if (!width || !height){
+        return;
+      }
+      boardState.viewportWidth = width;
+      boardState.viewportHeight = height;
+      const dpr = typeof window !== 'undefined' && window.devicePixelRatio ? window.devicePixelRatio : 1;
+      boardState.dpr = dpr;
+      const displayWidth = Math.round(width * dpr);
+      const displayHeight = Math.round(height * dpr);
+      if (canvasEl.width !== displayWidth || canvasEl.height !== displayHeight){
+        canvasEl.width = displayWidth;
+        canvasEl.height = displayHeight;
+      }
+      constrainPan();
+    };
+
+    const drawBoard = () => {
+      if (!boardState.viewportWidth || !boardState.viewportHeight){
+        updateCanvasSize();
+      }
+      const width = boardState.viewportWidth;
+      const height = boardState.viewportHeight;
+      if (!width || !height){
+        return;
+      }
+      const dpr = boardState.dpr || 1;
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.clearRect(0, 0, canvasEl.width, canvasEl.height);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      drawGrid(width, height);
+      updateCardTransform();
+    };
+
+    const drawGrid = (width, height) => {
+      const scale = boardState.scale;
+      const centerX = width / 2 + boardState.panX;
+      const centerY = height / 2 + boardState.panY;
+      const spacing = boardState.gridSpacing;
+      const extent = boardState.gridExtent;
+      const majorStep = boardState.majorStep;
+
+      const worldLeft = clampValue((0 - centerX) / scale, -extent, extent);
+      const worldRight = clampValue((width - centerX) / scale, -extent, extent);
+      const worldTop = clampValue((0 - centerY) / scale, -extent, extent);
+      const worldBottom = clampValue((height - centerY) / scale, -extent, extent);
+
+      const startXIndex = Math.floor(worldLeft / spacing) - 1;
+      const endXIndex = Math.ceil(worldRight / spacing) + 1;
+      const startYIndex = Math.floor(worldTop / spacing) - 1;
+      const endYIndex = Math.ceil(worldBottom / spacing) + 1;
+
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(75, 107, 255, 0.12)';
+      for (let ix = startXIndex; ix <= endXIndex; ix++){
+        if (ix % majorStep === 0) continue;
+        const screenX = centerX + ix * spacing * scale;
+        ctx.moveTo(screenX, 0);
+        ctx.lineTo(screenX, height);
+      }
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(75, 107, 255, 0.24)';
+      for (let ix = startXIndex; ix <= endXIndex; ix++){
+        if (ix % majorStep !== 0) continue;
+        const screenX = centerX + ix * spacing * scale;
+        ctx.moveTo(screenX, 0);
+        ctx.lineTo(screenX, height);
+      }
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(75, 107, 255, 0.12)';
+      for (let iy = startYIndex; iy <= endYIndex; iy++){
+        if (iy % majorStep === 0) continue;
+        const screenY = centerY + iy * spacing * scale;
+        ctx.moveTo(0, screenY);
+        ctx.lineTo(width, screenY);
+      }
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.strokeStyle = 'rgba(75, 107, 255, 0.24)';
+      for (let iy = startYIndex; iy <= endYIndex; iy++){
+        if (iy % majorStep !== 0) continue;
+        const screenY = centerY + iy * spacing * scale;
+        ctx.moveTo(0, screenY);
+        ctx.lineTo(width, screenY);
+      }
+      ctx.stroke();
+
+      ctx.beginPath();
+      ctx.lineWidth = 1.4;
+      ctx.strokeStyle = 'rgba(75, 107, 255, 0.32)';
+      ctx.moveTo(centerX, 0);
+      ctx.lineTo(centerX, height);
+      ctx.moveTo(0, centerY);
+      ctx.lineTo(width, centerY);
+      ctx.stroke();
+    };
+
+    const updateCardTransform = () => {
+      const width = boardState.viewportWidth;
+      const height = boardState.viewportHeight;
+      if (!width || !height){
+        return;
+      }
+      const scale = boardState.scale;
+      const centerX = width / 2 + boardState.panX;
+      const centerY = height / 2 + boardState.panY;
+      const card = boardState.card;
+
+      cardEl.style.width = `${card.width}px`;
+      cardEl.style.height = `${card.height}px`;
+      cardEl.style.transform = `translate(${centerX + card.x * scale}px, ${centerY + card.y * scale}px) scale(${scale})`;
+      cardEl.style.transformOrigin = 'top left';
+    };
+
+    const constrainPan = () => {
+      const scale = boardState.scale;
+      const width = boardState.viewportWidth;
+      const height = boardState.viewportHeight;
+      if (!width || !height){
+        return;
+      }
+      const halfWidthWorld = width / (2 * scale);
+      const halfHeightWorld = height / (2 * scale);
+      const limitX = Math.max(0, boardState.gridExtent - halfWidthWorld);
+      const limitY = Math.max(0, boardState.gridExtent - halfHeightWorld);
+      const maxPanX = limitX * scale;
+      const maxPanY = limitY * scale;
+      boardState.panX = clampValue(boardState.panX, -maxPanX, maxPanX);
+      boardState.panY = clampValue(boardState.panY, -maxPanY, maxPanY);
+    };
+
+    const startPan = (ev) => {
+      if (ev.button !== 0) return;
+      if (handleEl && handleEl.contains(ev.target)){
+        return;
+      }
+      boardState.isPanning = true;
+      boardState.pointerId = ev.pointerId;
+      boardState.lastPointerX = ev.clientX;
+      boardState.lastPointerY = ev.clientY;
+      boardEl.classList.add('layout-board--panning');
+      if (typeof boardEl.setPointerCapture === 'function'){
+        try { boardEl.setPointerCapture(ev.pointerId); } catch (err) {}
+      }
+      ev.preventDefault();
+    };
+
+    const continuePan = (ev) => {
+      if (!boardState.isPanning || ev.pointerId !== boardState.pointerId){
+        return;
+      }
+      const dx = (ev.clientX - boardState.lastPointerX) * boardState.panMultiplier;
+      const dy = (ev.clientY - boardState.lastPointerY) * boardState.panMultiplier;
+      boardState.panX += dx;
+      boardState.panY += dy;
+      boardState.lastPointerX = ev.clientX;
+      boardState.lastPointerY = ev.clientY;
+      constrainPan();
+      scheduleDraw();
+      ev.preventDefault();
+    };
+
+    const endPan = (ev) => {
+      if (!boardState.isPanning || (ev && ev.pointerId !== boardState.pointerId)){
+        return;
+      }
+      boardState.isPanning = false;
+      boardState.pointerId = null;
+      boardEl.classList.remove('layout-board--panning');
+      if (typeof boardEl.releasePointerCapture === 'function'){
+        try { boardEl.releasePointerCapture(ev.pointerId); } catch (err) {}
+      }
+      scheduleDraw();
+    };
+
+    const startResize = (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      boardState.isResizing = true;
+      boardState.resizePointerId = ev.pointerId;
+      boardState.resizeStart = {
+        x: ev.clientX,
+        y: ev.clientY,
+        width: boardState.card.width,
+        height: boardState.card.height
+      };
+      cardEl.classList.add('layout-board__card--resizing');
+      if (typeof handleEl.setPointerCapture === 'function'){
+        try { handleEl.setPointerCapture(ev.pointerId); } catch (err) {}
+      }
+    };
+
+    const continueResize = (ev) => {
+      if (!boardState.isResizing || ev.pointerId !== boardState.resizePointerId){
+        return;
+      }
+      const start = boardState.resizeStart;
+      const deltaX = (ev.clientX - start.x) / boardState.scale;
+      const deltaY = (ev.clientY - start.y) / boardState.scale;
+      const card = boardState.card;
+      card.width = clampValue(start.width + deltaX, card.minWidth, card.maxWidth);
+      card.height = clampValue(start.height + deltaY, card.minHeight, card.maxHeight);
+      scheduleDraw();
+    };
+
+    const endResize = (ev) => {
+      if (!boardState.isResizing || (ev && ev.pointerId !== boardState.resizePointerId)){
+        return;
+      }
+      boardState.isResizing = false;
+      boardState.resizePointerId = null;
+      boardState.resizeStart = null;
+      cardEl.classList.remove('layout-board__card--resizing');
+      if (typeof handleEl.releasePointerCapture === 'function'){
+        try { handleEl.releasePointerCapture(ev.pointerId); } catch (err) {}
+      }
+      scheduleDraw();
+    };
+
+    const handleWheel = (ev) => {
+      if (typeof ev.preventDefault === 'function'){
+        ev.preventDefault();
+      }
+      const delta = ev.deltaY || 0;
+      if (!boardState.viewportWidth || !boardState.viewportHeight){
+        updateCanvasSize();
+      }
+      const factor = Math.exp(-delta * 0.0015);
+      const previousScale = boardState.scale;
+      const nextScale = clampValue(previousScale * factor, boardState.minScale, boardState.maxScale);
+      if (Math.abs(nextScale - previousScale) < 0.001){
+        return;
+      }
+      const rect = boardEl.getBoundingClientRect();
+      const pointerX = ev.clientX - rect.left;
+      const pointerY = ev.clientY - rect.top;
+      const centerX = boardState.viewportWidth / 2;
+      const centerY = boardState.viewportHeight / 2;
+      const worldX = (pointerX - centerX - boardState.panX) / previousScale;
+      const worldY = (pointerY - centerY - boardState.panY) / previousScale;
+      boardState.scale = nextScale;
+      boardState.panX = pointerX - centerX - worldX * nextScale;
+      boardState.panY = pointerY - centerY - worldY * nextScale;
+      constrainPan();
+      scheduleDraw();
+    };
+
+    const cancelPanOnBlur = () => {
+      if (!boardState.isPanning){
+        return;
+      }
+      boardState.isPanning = false;
+      boardState.pointerId = null;
+      boardEl.classList.remove('layout-board--panning');
+    };
+
+    boardEl.addEventListener('pointerdown', startPan);
+    boardEl.addEventListener('pointermove', continuePan);
+    boardEl.addEventListener('pointerup', endPan);
+    boardEl.addEventListener('pointercancel', endPan);
+    boardEl.addEventListener('lostpointercapture', cancelPanOnBlur);
+    boardEl.addEventListener('wheel', handleWheel, { passive: false });
+
+    handleEl.addEventListener('pointerdown', startResize);
+    handleEl.addEventListener('pointermove', continueResize);
+    handleEl.addEventListener('pointerup', endResize);
+    handleEl.addEventListener('pointercancel', endResize);
+    handleEl.addEventListener('lostpointercapture', endResize);
+
+    const observeResize = () => {
+      updateCanvasSize();
+      scheduleDraw();
+    };
+
+    if (typeof ResizeObserver === 'function'){
+      const observer = new ResizeObserver(observeResize);
+      observer.observe(boardEl);
+    } else if (typeof window !== 'undefined' && window.addEventListener){
+      window.addEventListener('resize', observeResize, { passive: true });
+    }
+
+    updateCanvasSize();
+    drawBoard();
+  }
+
+  function clampValue(value, min, max){
+    if (value < min) return min;
+    if (value > max) return max;
+    return value;
   }
 
   function highlightAvailabilityCommand(index){


### PR DESCRIPTION
## Summary
- add a layout sandbox card to the popup with a much larger grid canvas and updated resize handle styling
- implement pan, scroll-to-zoom, and resize interactions for the preview card, including faster panning responsiveness

## Testing
- node popup.convert.test.js
- node converter.test.js
- node rbd.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e546d3c93c832682761dc6f658d680