### PR TITLE
Remove activeTab permission from manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,6 @@
     "128": "icons/icon128.png"
   },
   "permissions": [
-    "activeTab",
     "clipboardWrite",
     "storage"
   ],


### PR DESCRIPTION
## Summary
- remove the unused activeTab permission from the Chrome extension manifest

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69036c831bd88326aa5aa43632e57574